### PR TITLE
add initial changeset

### DIFF
--- a/.changeset/orange-carrots-boil.md
+++ b/.changeset/orange-carrots-boil.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": patch
+---
+
+Updates build and publish settings to npm


### PR DESCRIPTION
I'm finalizing the ci release flow. It's based on changesets. Typically we'd have more written, but just to get it going we're starting off with a patch. This should trigger a pr for the release.