### PR TITLE
feat: call /device/revoke endpoint on auth logout call

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -715,6 +715,53 @@ describe('production mode', () => {
     }, 15_000);
   });
 
+  describe('auth logout', () => {
+    it('sends POST to /device/revoke with refresh token then clears auth', async () => {
+      setResponseForUrl('/device/revoke', 200, 'ok');
+
+      const result = await runProdCli('auth', 'logout', '--output-json');
+
+      expect(result.exitCode).toBe(0);
+      const parsed = parseJson(result.stdout) as Record<string, unknown>;
+      expect(parsed.authenticated).toBe(false);
+
+      const revokeRequest = requests.find((r) =>
+        r.url.includes('/device/revoke'),
+      );
+      expect(revokeRequest).toBeDefined();
+      expect(revokeRequest?.method).toBe('POST');
+      const params = new URLSearchParams(revokeRequest?.body);
+      expect(params.get('token')).toBe(PROD_AUTH_TOKENS.refresh_token);
+      expect(params.get('client_id')).toBe('lwlpk_U7Qy7ThG69STZk');
+    });
+
+    it('clears local auth even when revoke call fails', async () => {
+      setResponseForUrl('/device/revoke', 500, {
+        error: 'server_error',
+      });
+
+      const result = await runProdCli('auth', 'logout', '--output-json');
+
+      expect(result.exitCode).toBe(0);
+      const parsed = parseJson(result.stdout) as Record<string, unknown>;
+      expect(parsed.authenticated).toBe(false);
+    });
+
+    it('succeeds when no auth tokens are stored', async () => {
+      storage.clearAuth();
+
+      const result = await runProdCli('auth', 'logout', '--output-json');
+
+      expect(result.exitCode).toBe(0);
+      const parsed = parseJson(result.stdout) as Record<string, unknown>;
+      expect(parsed.authenticated).toBe(false);
+      const revokeRequest = requests.find((r) =>
+        r.url.includes('/device/revoke'),
+      );
+      expect(revokeRequest).toBeUndefined();
+    });
+  });
+
   describe('auth guard', () => {
     it('rejects unauthenticated requests before hitting the API', async () => {
       storage.clearAuth();

--- a/packages/cli/src/auth/__tests__/auth-resource.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-resource.test.ts
@@ -172,6 +172,57 @@ describe('LinkAuthResource', () => {
     });
   });
 
+  describe('revokeToken', () => {
+    it('sends POST to /device/revoke with client_id and token', async () => {
+      mockFetchResponse(200, {});
+
+      const resource = createResource();
+      await resource.revokeToken('rt_to_revoke');
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://auth.test/device/revoke');
+      expect(opts.method).toBe('POST');
+
+      const params = new URLSearchParams(opts.body as string);
+      expect(params.get('client_id')).toBe('lwlpk_U7Qy7ThG69STZk');
+      expect(params.get('token')).toBe('rt_to_revoke');
+    });
+
+    it('resolves on 200 success', async () => {
+      mockFetchResponse(200, {});
+
+      const resource = createResource();
+      await expect(
+        resource.revokeToken('rt_valid'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('throws LinkApiError on non-2xx response', async () => {
+      mockFetchResponse(400, {
+        error: 'invalid_client',
+        error_description: 'invalid client_id',
+      });
+
+      const resource = createResource();
+      await expect(resource.revokeToken('rt_bad')).rejects.toThrow(
+        LinkApiError,
+      );
+      await expect(resource.revokeToken('rt_bad')).rejects.toThrow(
+        /Token revocation failed/,
+      );
+    });
+
+    it('throws LinkTransportError when fetch fails', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      const resource = createResource();
+      await expect(resource.revokeToken('rt_bad')).rejects.toThrow(
+        LinkTransportError,
+      );
+    });
+  });
+
   describe('refreshToken', () => {
     it('returns new tokens on success', async () => {
       mockFetchResponse(200, {

--- a/packages/cli/src/auth/__tests__/auth-resource.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-resource.test.ts
@@ -193,9 +193,7 @@ describe('LinkAuthResource', () => {
       mockFetchResponse(200, {});
 
       const resource = createResource();
-      await expect(
-        resource.revokeToken('rt_valid'),
-      ).resolves.toBeUndefined();
+      await expect(resource.revokeToken('rt_valid')).resolves.toBeUndefined();
     });
 
     it('throws LinkApiError on non-2xx response', async () => {

--- a/packages/cli/src/auth/__tests__/session.test.ts
+++ b/packages/cli/src/auth/__tests__/session.test.ts
@@ -15,6 +15,7 @@ function createMockAuthRepo(
     initiateDeviceAuth: vi.fn(),
     pollDeviceAuth: vi.fn(),
     refreshToken: vi.fn(async () => refreshResult),
+    revokeToken: vi.fn(async () => {}),
   };
 }
 

--- a/packages/cli/src/auth/auth-resource.ts
+++ b/packages/cli/src/auth/auth-resource.ts
@@ -187,6 +187,28 @@ export class LinkAuthResource implements IAuthResource {
     );
   }
 
+  async revokeToken(token: string): Promise<void> {
+    const { status, data, rawBody } = await this.postForm(
+      `${this.config.authBaseUrl}/device/revoke`,
+      {
+        client_id: CLIENT_ID,
+        token,
+      },
+    );
+
+    if (status < 200 || status >= 300) {
+      throw new LinkApiError(
+        formatOAuthError('Token revocation failed', status, data, rawBody),
+        {
+          status,
+          code: (data as OAuthError | null)?.error,
+          rawBody,
+          details: data,
+        },
+      );
+    }
+  }
+
   async refreshToken(refreshToken: string) {
     const { status, data, rawBody } = await this.postForm(
       `${this.config.authBaseUrl}/device/token`,

--- a/packages/cli/src/auth/types.ts
+++ b/packages/cli/src/auth/types.ts
@@ -13,4 +13,5 @@ export interface IAuthResource {
   initiateDeviceAuth(clientName?: string): Promise<DeviceAuthRequest>;
   pollDeviceAuth(deviceCode: string): Promise<AuthTokens | null>;
   refreshToken(refreshToken: string): Promise<AuthTokens>;
+  revokeToken(token: string): Promise<void>;
 }

--- a/packages/cli/src/commands/auth/index.tsx
+++ b/packages/cli/src/commands/auth/index.tsx
@@ -122,11 +122,21 @@ export function registerAuthCommands(
       await executeCommand({
         outputJson: !!options.outputJson,
         jsonFn: async () => {
+          const auth = storage.getAuth();
+          if (auth?.refresh_token) {
+            try {
+              await authResource.revokeToken(auth.refresh_token);
+            } catch {
+              // best-effort: clear local storage regardless
+            }
+          }
           storage.clearAuth();
           storage.deleteConfig();
           return { authenticated: false };
         },
-        renderFn: () => <Logout onComplete={() => {}} />,
+        renderFn: () => (
+          <Logout authResource={authResource} onComplete={() => {}} />
+        ),
       });
     });
 

--- a/packages/cli/src/commands/auth/logout.tsx
+++ b/packages/cli/src/commands/auth/logout.tsx
@@ -2,20 +2,36 @@ import { storage } from '@stripe/link-sdk';
 import { Box, Text } from 'ink';
 import type React from 'react';
 import { useEffect, useState } from 'react';
+import type { IAuthResource } from '../../auth/types';
 
 interface LogoutProps {
+  authResource: IAuthResource;
   onComplete: () => void;
 }
 
-export const Logout: React.FC<LogoutProps> = ({ onComplete }) => {
+export const Logout: React.FC<LogoutProps> = ({
+  authResource,
+  onComplete,
+}) => {
   const [done, setDone] = useState(false);
 
   useEffect(() => {
-    storage.clearAuth();
-    storage.deleteConfig();
-    setDone(true);
-    setTimeout(onComplete, 1000);
-  }, [onComplete]);
+    const run = async () => {
+      const auth = storage.getAuth();
+      if (auth?.refresh_token) {
+        try {
+          await authResource.revokeToken(auth.refresh_token);
+        } catch {
+          // best-effort: clear local storage regardless
+        }
+      }
+      storage.clearAuth();
+      storage.deleteConfig();
+      setDone(true);
+      setTimeout(onComplete, 1000);
+    };
+    run();
+  }, [authResource, onComplete]);
 
   if (!done) {
     return null;

--- a/packages/cli/src/commands/auth/logout.tsx
+++ b/packages/cli/src/commands/auth/logout.tsx
@@ -9,10 +9,7 @@ interface LogoutProps {
   onComplete: () => void;
 }
 
-export const Logout: React.FC<LogoutProps> = ({
-  authResource,
-  onComplete,
-}) => {
+export const Logout: React.FC<LogoutProps> = ({ authResource, onComplete }) => {
   const [done, setDone] = useState(false);
 
   useEffect(() => {

--- a/packages/sdk/src/resources/__tests__/auth.test.ts
+++ b/packages/sdk/src/resources/__tests__/auth.test.ts
@@ -258,6 +258,51 @@ describe('AuthResource', () => {
     });
   });
 
+  describe('revokeToken', () => {
+    it('sends correct request parameters', async () => {
+      mockFetchResponse(200, {});
+
+      await repo.revokeToken('rt_to_revoke');
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://login.link.com/device/revoke');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['Content-Type']).toBe(
+        'application/x-www-form-urlencoded',
+      );
+
+      const params = new URLSearchParams(opts.body);
+      expect(params.get('client_id')).toBe('lwlpk_U7Qy7ThG69STZk');
+      expect(params.get('token')).toBe('rt_to_revoke');
+    });
+
+    it('resolves on 200 success', async () => {
+      mockFetchResponse(200, {});
+
+      await expect(repo.revokeToken('rt_valid')).resolves.toBeUndefined();
+    });
+
+    it('throws on HTTP error with error_description', async () => {
+      mockFetchResponse(400, {
+        error: 'invalid_client',
+        error_description: 'invalid client_id',
+      });
+
+      await expect(repo.revokeToken('rt_bad')).rejects.toThrow(
+        'Token revocation failed (400): invalid client_id',
+      );
+    });
+
+    it('handles non-JSON error body gracefully', async () => {
+      mockFetchRawResponse(502, 'Bad Gateway');
+
+      await expect(repo.revokeToken('rt_bad')).rejects.toThrow(
+        'Token revocation failed (502): Bad Gateway',
+      );
+    });
+  });
+
   describe('refreshToken', () => {
     it('returns new AuthTokens on success', async () => {
       mockFetchResponse(200, {

--- a/packages/sdk/src/resources/auth.ts
+++ b/packages/sdk/src/resources/auth.ts
@@ -186,6 +186,28 @@ export class AuthResource implements IAuthResource {
     );
   }
 
+  async revokeToken(token: string): Promise<void> {
+    const { status, data, rawBody } = await this.postForm(
+      `${this.config.authBaseUrl}/device/revoke`,
+      {
+        client_id: CLIENT_ID,
+        token,
+      },
+    );
+
+    if (status < 200 || status >= 300) {
+      throw new LinkApiError(
+        formatOAuthError('Token revocation failed', status, data, rawBody),
+        {
+          status,
+          code: (data as OAuthError | null)?.error,
+          rawBody,
+          details: data,
+        },
+      );
+    }
+  }
+
   async refreshToken(refreshToken: string): Promise<AuthTokens> {
     const { status, data, rawBody } = await this.postForm(
       `${this.config.authBaseUrl}/device/token`,

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -13,6 +13,7 @@ export interface IAuthResource {
   initiateDeviceAuth(clientName?: string): Promise<DeviceAuthRequest>;
   pollDeviceAuth(deviceCode: string): Promise<AuthTokens | null>;
   refreshToken(refreshToken: string): Promise<AuthTokens>;
+  revokeToken(token: string): Promise<void>;
 }
 
 export interface GetAccessTokenOptions {


### PR DESCRIPTION
Updates the `auth logout` command to call the `/device/revoke` endpoint to revoke associated tokens on the OAuth server. Gracefully handles errors so that the local auth data is still cleared if the request to `/device/revoke` fails, which is the current experience.