### PR TITLE
Replace passphrase with phrase across repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The `link-cli` requires a Link account. You can login to your existing one or [r
 link-cli auth login
 ```
 
-You'll receive a verification URL and a short passphrase. Visit the URL, log in to your Link account, and enter the passphrase to approve the connection.
+You'll receive a verification URL and a short phrase. Visit the URL, log in to your Link account, and enter the phrase to approve the connection.
 
 ### List payment methods
 

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -709,7 +709,7 @@ describe('production mode', () => {
       expect(output[0].verification_url).toBe(
         'https://app.link.com/device/setup?code=apple-grape',
       );
-      expect(output[0].passphrase).toBe('apple-grape');
+      expect(output[0].phrase).toBe('apple-grape');
       const next = output[0]._next as Record<string, unknown>;
       expect(next.command).toContain('auth status');
       expect(next.until).toContain('authenticated');

--- a/packages/cli/src/commands/auth/index.tsx
+++ b/packages/cli/src/commands/auth/index.tsx
@@ -49,11 +49,11 @@ export function createAuthCli(authResource: IAuthResource) {
         interval: authRequest.interval,
         expires_at: Date.now() + authRequest.expires_in * 1000,
         verification_url: authRequest.verification_url_complete,
-        passphrase: authRequest.user_code,
+        phrase: authRequest.user_code,
       });
       yield {
         verification_url: authRequest.verification_url_complete,
-        passphrase: authRequest.user_code,
+        phrase: authRequest.user_code,
         instruction:
           'Present the verification_url to the user and ask them to approve in the Link app. Then call `auth status --interval 5 --max-attempts 60` to poll until authenticated. Do not wait for the user to reply — start polling immediately.',
         _next: {
@@ -136,7 +136,7 @@ export function createAuthCli(authResource: IAuthResource) {
             ? {
                 pending: true,
                 verification_url: currentPending.verification_url,
-                passphrase: currentPending.passphrase,
+                phrase: currentPending.phrase,
               }
             : {}),
         };

--- a/packages/cli/src/commands/auth/login.tsx
+++ b/packages/cli/src/commands/auth/login.tsx
@@ -132,7 +132,7 @@ export const Login: React.FC<LoginProps> = ({
         </Text>
         <Text dimColor>Press Enter to open in browser</Text>
         <Text>
-          Enter passphrase:{' '}
+          Enter phrase:{' '}
           <Text bold color="yellow">
             {userCode}
           </Text>

--- a/packages/sdk/src/utils/storage.ts
+++ b/packages/sdk/src/utils/storage.ts
@@ -7,7 +7,7 @@ export interface PendingDeviceAuth {
   interval: number;
   expires_at: number;
   verification_url: string;
-  passphrase: string;
+  phrase: string;
 }
 
 interface StorageSchema {

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -45,7 +45,7 @@ IMPORTANT: Run `auth login`, `spend-request create`, and `spend-request request-
 
 The JSON stream contract for these long-running commands is:
 
-- `auth login --format json`: first object contains `verification_url` and `passphrase`; final object contains authentication result after approval succeeds
+- `auth login --format json`: first object contains `verification_url` and `phrase`; final object contains authentication result after approval succeeds
 - `spend-request create --request-approval --format json`: first object is the created spend request; final object is the terminal spend request after polling completes
 - `spend-request request-approval --format json`: first object contains the approval link; final object is the terminal spend request after polling completes
 
@@ -77,7 +77,7 @@ If not authenticated:
 link-cli auth login --client-name "<your-agent-name>" --format json
 ```
 
-Replace `<your-agent-name>` with the name of your agent or application (e.g. `"Personal Assistant", "Shopping Bot"`). This name appears in the user's Link app when they approve the connection. Use a clear, unique, identifiable name. Display the url and passphrase to the user, with the guidance "Please visit the following URL to approve secure access to Link.”
+Replace `<your-agent-name>` with the name of your agent or application (e.g. `"Personal Assistant", "Shopping Bot"`). This name appears in the user's Link app when they approve the connection. Use a clear, unique, identifiable name. Display the url and phrase to the user, with the guidance "Please visit the following URL to approve secure access to Link.”
 
 DO NOT PROCEED until the user is authenticated with Link.
 


### PR DESCRIPTION
**CHANGES**
Updates from passphrase to "phrase" to match the language used in link.com. 

<img width="409" height="189" alt="image" src="https://github.com/user-attachments/assets/f384a283-caac-4961-98ee-ba2a6cd0b171" />
