### PR TITLE
Fix Card.valid_until type to match API response

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -607,7 +607,7 @@ describe('production mode', () => {
             postal_code: '94111',
             country: 'US',
           },
-          valid_until: 1750000000,
+          valid_until: '2025-06-15T06:13:20Z',
         },
       });
 
@@ -624,7 +624,7 @@ describe('production mode', () => {
       expect(request.status).toBe('approved');
       const card = request.card as Record<string, unknown>;
       expect(card.number).toBe('4242424242424242');
-      expect(card.valid_until).toBe(1750000000);
+      expect(card.valid_until).toBe('2025-06-15T06:13:20Z');
       const billingAddress = card.billing_address as Record<string, unknown>;
       expect(billingAddress.name).toBe('Jane Doe');
       expect(billingAddress.line1).toBe('123 Main St');

--- a/packages/cli/src/commands/spend-request/retrieve.tsx
+++ b/packages/cli/src/commands/spend-request/retrieve.tsx
@@ -282,10 +282,7 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
             {request?.card.valid_until && (
               <Text>
                 {' '}
-                Valid Until:{' '}
-                <Text bold>
-                  {request.card.valid_until}
-                </Text>
+                Valid Until: <Text bold>{request.card.valid_until}</Text>
               </Text>
             )}
             {request?.card.billing_address && (

--- a/packages/cli/src/commands/spend-request/retrieve.tsx
+++ b/packages/cli/src/commands/spend-request/retrieve.tsx
@@ -284,7 +284,7 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
                 {' '}
                 Valid Until:{' '}
                 <Text bold>
-                  {new Date(request.card.valid_until * 1000).toISOString()}
+                  {request.card.valid_until}
                 </Text>
               </Text>
             )}

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -52,7 +52,7 @@ export interface Card {
   number: string;
   cvc?: string;
   billing_address?: BillingAddress;
-  valid_until?: number;
+  valid_until?: string;
 }
 
 export type SpendRequestStatus =


### PR DESCRIPTION
## Summary
- The API returns `card.valid_until` as an ISO 8601 string, but the `Card` type declared it as `number`
- The interactive retrieve component did `new Date(valid_until * 1000).toISOString()`, producing `NaN` and crashing with `RangeError: Invalid time value`
- Fixed the type to `string` and display the value directly

## Test plan
- [x] `pnpm run typecheck` passes
- [x] `pnpm vitest run src/__tests__/cli.test.ts` — 33/33 tests pass
- [x] Manual: `spend-request retrieve --include=card <id>` works in interactive mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)