### PR TITLE
polling commands only emit when response has changed

### DIFF
--- a/.changeset/slimy-meals-tie.md
+++ b/.changeset/slimy-meals-tie.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": patch
+---
+
+Polling commands now only emit results when the response has changed, reducing noise in agent logs.

--- a/packages/cli/src/commands/auth/index.tsx
+++ b/packages/cli/src/commands/auth/index.tsx
@@ -108,6 +108,7 @@ export function createAuthCli(
       const maxAttempts = opts.maxAttempts;
       const deadline = Date.now() + opts.timeout * 1000;
       let attempts = 0;
+      let previousAttemptData: string | undefined;
 
       while (true) {
         // If there's a pending device auth, try one poll to see if the user approved.
@@ -164,8 +165,12 @@ export function createAuthCli(
           return;
         }
 
-        // Yield current status as MCP progress notification, then wait
-        yield status;
+        // Only yield when status has changed to avoid noisy agent transcripts
+        const snapshot = JSON.stringify(status);
+        if (snapshot !== previousAttemptData) {
+          previousAttemptData = snapshot;
+          yield status;
+        }
         await new Promise((resolve) => setTimeout(resolve, interval * 1000));
       }
     },

--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -311,6 +311,7 @@ export function createSpendRequestCli(repository: ISpendRequestResource) {
       ]);
       const deadline = Date.now() + timeout * 1000;
       let attempts = 0;
+      let previousAttemptData: string | undefined;
 
       while (true) {
         const request = await repository.getSpendRequest(id, { include });
@@ -337,7 +338,12 @@ export function createSpendRequestCli(repository: ISpendRequestResource) {
           return;
         }
 
-        yield request;
+        // Only yield when the response has changed to avoid noisy agent transcripts
+        const snapshot = JSON.stringify(request);
+        if (snapshot !== previousAttemptData) {
+          previousAttemptData = snapshot;
+          yield request;
+        }
         await new Promise((resolve) => setTimeout(resolve, interval * 1000));
       }
     },


### PR DESCRIPTION
Fixes https://github.com/stripe/link-cli/issues/32

Instead of logging out the results of a poll every time, it only logs if there is a change. This reduces excessive logging/transcripts and reduces excessive token use.