### PR TITLE
fix tests

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -111,6 +111,7 @@ async function runProdCli(...args: string[]): Promise<CliResult> {
           ...process.env,
           LINK_API_BASE_URL: `http://127.0.0.1:${serverPort}`,
           LINK_AUTH_BASE_URL: `http://127.0.0.1:${serverPort}`,
+          XDG_DATA_HOME: '/tmp/link-cli-test-empty',
         },
         timeout: 10_000,
       },


### PR DESCRIPTION
Ensures tests run from a clean dir so `incur` doesn't complain about out of date skill files etc.