### PR TITLE
Add back human output for auth status

### DIFF
--- a/packages/cli/src/commands/auth/index.tsx
+++ b/packages/cli/src/commands/auth/index.tsx
@@ -103,6 +103,27 @@ export function createAuthCli(
     options: statusOptions,
     outputPolicy: 'agent-only' as const,
     async *run(c) {
+      if (!c.agent && !c.formatExplicit) {
+        return new Promise((resolve) => {
+          const { waitUntilExit } = render(
+            <AuthStatus onComplete={() => {}} />,
+          );
+          waitUntilExit().then(() => {
+            const auth = storage.getAuth();
+            resolve({
+              authenticated: !!auth,
+              ...(auth
+                ? {
+                    access_token: `${auth.access_token.substring(0, 20)}...`,
+                    token_type: auth.token_type,
+                  }
+                : {}),
+              credentials_path: storage.getPath(),
+            });
+          });
+        });
+      }
+
       const opts = c.options;
       const interval = opts.interval;
       const maxAttempts = opts.maxAttempts;


### PR DESCRIPTION
When switching to `incur`, we dropped the human output for `link-cli auth status`. This change adds it back.

<img width="759" height="200" alt="Screenshot 2026-04-28 at 5 20 46 PM" src="https://github.com/user-attachments/assets/48c65df1-87a9-4315-8e78-0064bcb7eb45" />
