### PR TITLE
fix(sdk): restrict the auth config file to the owning user (mode 0o600)

### DIFF
--- a/.changeset/auth-config-file-mode.md
+++ b/.changeset/auth-config-file-mode.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": patch
+---
+
+Restrict the auth config file (`config.json`) to mode `0o600`. The file holds OAuth access + refresh tokens and, during a pending login, a `device_code`. Previously it inherited `conf`'s default (`0o666` masked by umask, typically `0o644`), which let other local users read the credentials and, during a login, race the legitimate poll loop to `/device/token`. Existing files are remediated automatically on the next config write.

--- a/packages/sdk/src/utils/__tests__/storage.test.ts
+++ b/packages/sdk/src/utils/__tests__/storage.test.ts
@@ -1,5 +1,8 @@
-import { MemoryStorage } from '@/utils/storage';
-import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { MemoryStorage, Storage } from '@/utils/storage';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 describe('MemoryStorage', () => {
   it('computes expires_at when storing auth tokens', () => {
@@ -39,5 +42,80 @@ describe('MemoryStorage', () => {
     expect(() => authStorage.deleteConfig()).not.toThrow();
     // auth is unaffected
     expect(authStorage.isAuthenticated()).toBe(true);
+  });
+});
+
+// Skip on Windows: POSIX file modes don't apply (NTFS uses ACLs and the
+// stat.mode bits don't reflect the actual access controls).
+const describePosix = process.platform === 'win32' ? describe.skip : describe;
+
+describePosix('Storage (disk-backed) file permissions', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'link-cli-storage-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes the config file with mode 0o600 (owner-only)', () => {
+    const storage = new Storage({ cwd: tmpDir });
+
+    storage.setAuth({
+      access_token: 'at_test',
+      refresh_token: 'rt_test',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+
+    const mode = fs.statSync(storage.getPath()).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  // The fix must also remediate users who were created on a prior version that
+  // wrote the file with the conf default (0o666 masked by umask, typically
+  // 0o644). conf writes via atomic rename, so the new mode applies on the
+  // next write — no explicit chmod needed.
+  it('rewrites with mode 0o600 when an existing file is 0o644', () => {
+    const seedStorage = new Storage({ cwd: tmpDir });
+    // Trigger initial write so we know where the file lives.
+    seedStorage.setAuth({
+      access_token: 'at_seed',
+      refresh_token: 'rt_seed',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+    const configPath = seedStorage.getPath();
+    fs.chmodSync(configPath, 0o644);
+    expect(fs.statSync(configPath).mode & 0o777).toBe(0o644);
+
+    // Simulate a CLI invocation after the upgrade: a new Storage instance
+    // opens the same file and writes (e.g., via a refreshed token).
+    const upgradedStorage = new Storage({ cwd: tmpDir });
+    upgradedStorage.setAuth({
+      access_token: 'at_after_upgrade',
+      refresh_token: 'rt_after_upgrade',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+
+    expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+  });
+
+  it('also restricts pendingDeviceAuth, which is written to the same file', () => {
+    const storage = new Storage({ cwd: tmpDir });
+
+    storage.setPendingDeviceAuth({
+      device_code: 'dc_test_must_not_leak',
+      interval: 5,
+      expires_at: Date.now() + 60_000,
+      verification_url: 'https://login.link.com/device',
+      phrase: 'test-phrase',
+    });
+
+    const mode = fs.statSync(storage.getPath()).mode & 0o777;
+    expect(mode).toBe(0o600);
   });
 });

--- a/packages/sdk/src/utils/storage.ts
+++ b/packages/sdk/src/utils/storage.ts
@@ -35,13 +35,35 @@ function withComputedExpiry(auth: AuthTokens): AuthTokens {
   };
 }
 
-class Storage implements AuthStorage {
+// Restricts the on-disk config to the owning user only. The file holds
+// OAuth access + refresh tokens and, during the device-auth window, a
+// device_code. `conf` defaults to 0o666 (masked by umask to 0o644 on most
+// systems), which would let any other local user read the credentials and,
+// during a pending login, race the legitimate poll loop to /device/token.
+// Owner-only matches the convention used by gh, aws, and similar CLIs.
+const CONFIG_FILE_MODE = 0o600;
+
+export interface StorageOptions {
+  // Override the conf storage directory. Production callers pass nothing —
+  // conf resolves to the platform user-config directory. Tests pass a temp
+  // dir so they don't touch the real location.
+  cwd?: string;
+}
+
+export class Storage implements AuthStorage {
   private config?: Conf<StorageSchema>;
+  private readonly options: StorageOptions;
+
+  constructor(options: StorageOptions = {}) {
+    this.options = options;
+  }
 
   private getConfig(): Conf<StorageSchema> {
     if (!this.config) {
       this.config = new Conf<StorageSchema>({
         projectName: 'link-cli',
+        configFileMode: CONFIG_FILE_MODE,
+        ...(this.options.cwd ? { cwd: this.options.cwd } : {}),
         defaults: {
           auth: null,
           pendingDeviceAuth: null,


### PR DESCRIPTION
## Summary

`Storage` (`packages/sdk/src/utils/storage.ts:38`) constructs `Conf` without passing `configFileMode`, so the on-disk file at the platform user-config path (e.g. `~/Library/Preferences/link-cli-nodejs/config.json` on macOS) inherits the conf default — `0o666` masked by umask, which on stock macOS / Linux installs lands at `0o644`.

I verified empirically: a fresh write through the existing `Storage` produces a file with mode `0o644` and a parent dir at `0o755`.

The file holds:

- `auth.access_token` and `auth.refresh_token` minted by `auth login` (`packages/sdk/src/resources/auth.ts`).
- `pendingDeviceAuth.device_code` and verification phrase written by agent-mode `auth login` at `packages/cli/src/commands/auth/index.tsx:50` so `auth status --interval` can resume polling across CLI invocations.

With `0o644`, any other local user (shared dev workstations, multi-user CI runners, lab machines) can read this file. Two consequences I want to flag honestly:

1. **Token disclosure.** With access + refresh tokens, the reader can call the Link API as the victim — including the documented `GET /spend_requests/{id}?include=card` path that returns unmasked card details from approved spend requests.
2. **device_code exposure during a pending login.** The OAuth 2.0 device authorization grant treats `device_code` as the polling client's secret; the spec does not bind it to a single client process. A second process that holds the same `device_code` can poll `/device/token` independently. Whether that lets a co-resident attacker actually capture the tokens at user-approval time depends on Stripe's server-side handling of duplicate polls; I did not test against the live API, so I am noting this as a primitive the perms regression exposes, not a confirmed end-to-end exploit.

Owner-only `0o600` is the standard across credential-bearing CLIs (gh, aws, mercury-cli, etc.). The aim of this PR is to bring link-cli in line with that baseline.

## Approach

Pass `configFileMode: 0o600` to the `Conf` constructor. `conf` writes via atomic rename, so existing `0o644` files inherited from a prior install are remediated on the next config write (`setAuth`, `clearAuth`, `setPendingDeviceAuth`) — verified empirically. No separate migration code needed.

The `Storage` class is now exported and accepts an optional `cwd` so unit tests can run against a temp directory instead of the real platform user-config path. Production callers use the `storage` singleton unchanged.

## Test plan

- [x] `writes the config file with mode 0o600 (owner-only)` — fresh write asserts mode after `setAuth`.
- [x] `rewrites with mode 0o600 when an existing file is 0o644` — pre-creates a `0o644` file, then writes via the fixed `Storage` and asserts the mode flips to `0o600`. Covers the upgrade path from a pre-fix install.
- [x] `also restricts pendingDeviceAuth, which is written to the same file` — covers the device_code window.
- All three skipped on Windows (NTFS uses ACLs; POSIX mode bits don't reflect actual access controls).
- [x] `pnpm run test` — 93 tests, all green.
- [x] `pnpm run typecheck` green.
- [x] `pnpm biome check .` green.
- [x] Changeset added (`@stripe/link-cli` patch).

## Notes for review

- Found during a focused review of the auth + spend-request paths the day after the public release. Nothing else from this pass jumped out as worth opening as a separate PR right now.
- Happy to mirror future findings via HackerOne if your team prefers that channel for hardening fixes; routed this one as a PR because the fix is one line and the scope was narrow.