### PR TITLE
fix: fail spend request polling when no terminal status is reached

### DIFF
--- a/.changeset/polling-timeout-pending.md
+++ b/.changeset/polling-timeout-pending.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": patch
+---
+
+Exit non-zero when spend request polling exhausts its timeout or max attempts before reaching a terminal status.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ Key input field notes:
 - CLI input uses `payment_method_id`; mapped to `payment_details` when calling the SDK
 - `context` requires min 100 characters; `amount` is in cents with max 50000
 - `--test` flag creates testmode credentials (real testmode SPT from test card data) instead of livemode ones
-- `create --request-approval` and `request-approval` both show an approval URL in interactive mode and poll until approved/denied/expired/failed. In JSON mode (`--format json`), they block silently and return the final `SpendRequest` when complete.
+- `create --request-approval` and `request-approval` both show an approval URL in interactive mode and poll until approved/denied/expired/failed. In JSON mode (`--format json`), they return immediately with an `_next.command` for `spend-request retrieve`.
+- `retrieve --interval <seconds>` polls until approved/denied/expired/succeeded/failed. If `--timeout` is reached or `--max-attempts` is exhausted while the request is still non-terminal, it exits non-zero with `POLLING_TIMEOUT`.
 - `card` credentials include `billing_address` (name, line1, line2, city, state, postal_code, country) and `valid_until` (ISO date string — when the card expires/stops working)
 
 ### mpp pay

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ link-cli spend-request retrieve lsrq_001 --format json
 ```
 By default, retrieving a spend request will not include card details. Use the `--include=card` to see unmasked card details.
 
+For agent polling, pass `--interval` and optionally `--max-attempts`:
+
+```bash
+link-cli spend-request retrieve lsrq_001 --interval 2 --max-attempts 150 --format json
+```
+
+Polling exits successfully only after the request reaches a terminal status such as `approved`, `denied`, or `expired`. If polling reaches `--timeout` or exhausts `--max-attempts` while the request is still non-terminal, the command exits non-zero with `code: "POLLING_TIMEOUT"` so callers do not treat a still-pending request as complete.
+
 If the merchant supports MPP, use `link-cli mpp pay` instead:
 
 ```bash

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -650,6 +650,78 @@ describe('production mode', () => {
       const output = result.stdout + result.stderr;
       expect(output).toContain('not found');
     });
+
+    it('exits non-zero when polling attempts are exhausted before a terminal status', async () => {
+      setNextResponse(200, {
+        ...BASE_REQUEST,
+        status: 'pending_approval',
+        approval_url: 'https://app.link.com/approve/lsrq_prod_001',
+      });
+
+      const result = await runProdCli(
+        'spend-request',
+        'retrieve',
+        'lsrq_prod_001',
+        '--interval',
+        '1',
+        '--max-attempts',
+        '1',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(1);
+      const output = parseJson(result.stdout) as Record<string, unknown>;
+      expect(output.code).toBe('POLLING_TIMEOUT');
+      expect(output.message).toContain('pending_approval');
+      expect(output.message).toContain('max attempts');
+    });
+
+    it('exits non-zero when polling times out before a terminal status', async () => {
+      setNextResponse(200, {
+        ...BASE_REQUEST,
+        status: 'pending_approval',
+        approval_url: 'https://app.link.com/approve/lsrq_prod_001',
+      });
+
+      const result = await runProdCli(
+        'spend-request',
+        'retrieve',
+        'lsrq_prod_001',
+        '--interval',
+        '1',
+        '--timeout',
+        '0',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(1);
+      const output = parseJson(result.stdout) as Record<string, unknown>;
+      expect(output.code).toBe('POLLING_TIMEOUT');
+      expect(output.message).toContain('pending_approval');
+      expect(output.message).toContain('timeout');
+    });
+
+    it('exits successfully when polling observes a terminal status', async () => {
+      setNextResponse(200, {
+        ...BASE_REQUEST,
+        status: 'approved',
+      });
+
+      const result = await runProdCli(
+        'spend-request',
+        'retrieve',
+        'lsrq_prod_001',
+        '--interval',
+        '1',
+        '--max-attempts',
+        '1',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      const output = parseJson(result.stdout) as Record<string, unknown>[];
+      expect(output[0].status).toBe('approved');
+    });
   });
 
   describe('auth login', () => {

--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -338,14 +338,22 @@ export function createSpendRequestCli(repository: ISpendRequestResource) {
         }
 
         attempts++;
-        const shouldStop =
-          interval <= 0 ||
-          (maxAttempts > 0 && attempts >= maxAttempts) ||
-          Date.now() >= deadline;
-
-        if (shouldStop) {
+        if (interval <= 0) {
           yield request;
           return;
+        }
+
+        const maxAttemptsExhausted = maxAttempts > 0 && attempts >= maxAttempts;
+        const timeoutReached = Date.now() >= deadline;
+        if (maxAttemptsExhausted || timeoutReached) {
+          const reason = maxAttemptsExhausted
+            ? `max attempts (${maxAttempts}) exhausted`
+            : `timeout (${timeout}s) reached`;
+          return c.error({
+            code: 'POLLING_TIMEOUT',
+            message: `Polling stopped before spend request ${id} reached a terminal status: ${reason}; current status is ${request.status}.`,
+            retryable: true,
+          });
         }
 
         // Only yield when the response has changed to avoid noisy agent transcripts

--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -63,17 +63,21 @@ export const retrieveOptions = z.object({
   timeout: z.coerce
     .number()
     .default(300)
-    .describe('Polling timeout in seconds'),
+    .describe(
+      'Polling timeout in seconds. When reached during active polling, exits non-zero with POLLING_TIMEOUT.',
+    ),
   interval: z.coerce
     .number()
     .default(0)
     .describe(
-      'Poll interval in seconds. When > 0, polls until status is terminal or timeout is reached, yielding status on each attempt.',
+      'Poll interval in seconds. When > 0, polls until status is terminal, timeout is reached, or max attempts are exhausted.',
     ),
   maxAttempts: z.coerce
     .number()
     .default(0)
-    .describe('Max poll attempts. 0 = unlimited (use timeout instead).'),
+    .describe(
+      'Max poll attempts. 0 = unlimited. Exhaustion during active polling exits non-zero with POLLING_TIMEOUT.',
+    ),
   include: z
     .array(z.string())
     .default([])

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -55,15 +55,16 @@ The rest of this document shows CLI commands. When using the MCP server, map eac
 
 All commands support `--format json` for machine-readable output. Pass input via flags (run `link-cli <command> --help` to see full schema details, including all fields, types, and constraints).
 
-IMPORTANT: Run `auth login`, `spend-request create`, and `spend-request request-approval` with `run_in_background=true` (or `TaskOutput(task_id, block: false)`). These commands emit JSON to stdout before they exit, then keep running while they poll for user action.
+IMPORTANT: Run `auth login` with `run_in_background=true` (or `TaskOutput(task_id, block: false)`). It emits JSON to stdout before it exits, then keeps running while it polls for user action.
 
-The JSON stream contract for these long-running commands is:
+The agent-facing JSON contract is:
 
 - `auth login --format json`: first object contains `verification_url` and `phrase`; final object contains authentication result after approval succeeds
-- `spend-request create --request-approval --format json`: first object is the created spend request; final object is the terminal spend request after polling completes
-- `spend-request request-approval --format json`: first object contains the approval link; final object is the terminal spend request after polling completes
+- `spend-request create --request-approval --format json`: returns the created spend request immediately with an `_next.command` polling hint
+- `spend-request request-approval --format json`: returns the approval link immediately with an `_next.command` polling hint
+- `spend-request retrieve <id> --interval <seconds> --format json`: polls until the spend request reaches a terminal status, then returns the terminal spend request. It exits non-zero with `code: "POLLING_TIMEOUT"` if `--timeout` is reached or `--max-attempts` is exhausted while the request is still non-terminal.
 
-Always keep reading stdout until the process exits. Do not assume the first JSON object is the full result. The user MUST visit the verification or approval URL to continue, and you should always show that full URL in clear text.
+For `auth login`, keep reading stdout until the process exits. For spend request approval, present the `approval_url` to the user and start the `_next.command` polling command immediately. The user MUST visit the verification or approval URL to continue, and you should always show that full URL in clear text.
 
 ## Core flow
 
@@ -148,7 +149,7 @@ link-cli spend-request create \
   --format json
 ```
 
-Wait until the user has approved the spend request. If they deny, ask for clarification what to do next.
+After creating or requesting approval for a spend request, run the returned `_next.command` to poll for the terminal status. Do not proceed to payment while the request is still `created` or `pending_approval`. If polling exits with `POLLING_TIMEOUT`, keep waiting or ask the user whether to continue polling. If they deny, ask for clarification what to do next.
 
 Recommend the user approves with the [Link app](https://link.com/download). Show the download URL.
 


### PR DESCRIPTION
Fixes #55

## Problem

`spend-request create --request-approval` returns an `_next.command` that tells callers to poll with:

```bash
link-cli spend-request retrieve <id> --interval 2 --max-attempts 150
```

Before this change, if that polling command exhausted `--max-attempts` or reached `--timeout` while the spend request was still `pending_approval`, the CLI returned the still-pending spend request and exited successfully.

That makes the state ambiguous for automation: exit code 0 can look like "approval flow completed," even though no terminal approval, denial, or expiration was reached.

## Solution

This changes active polling behavior so exhaustion is explicit:

- `retrieve` still returns successfully when it sees a terminal status:
  - `approved`
  - `denied`
  - `expired`
  - `succeeded`
  - `failed`
- One-shot retrieve behavior is preserved when polling is not enabled.
- When `--interval > 0` and polling exhausts `--max-attempts` or reaches `--timeout` before a terminal status, the command now exits non-zero with `POLLING_TIMEOUT`.
- The error message includes the exhaustion reason and the current non-terminal spend request status.

This keeps successful JSON output stable for completed polling, while making "still pending after polling limit" mechanically distinguishable from completion.

## Example

```bash
link-cli spend-request retrieve lsrq_123 --interval 2 --max-attempts 150 --format json
```

If the request is still pending after the polling limit:

```json
{
  "code": "POLLING_TIMEOUT",
  "message": "Polling stopped before spend request lsrq_123 reached a terminal status: max attempts (150) exhausted; current status is pending_approval.",
  "retryable": true
}
```

## Docs and release note

This also updates:

- CLI option descriptions for `--timeout`, `--interval`, and `--max-attempts`
- README polling guidance
- agent-facing Link CLI skill instructions
- `CLAUDE.md` command behavior notes
- patch changeset for `@stripe/link-cli`

## Tests

- `pnpm biome check .`
- `pnpm exec turbo run typecheck --force`
- `pnpm exec turbo run test --force`