### PR TITLE
Add viem as an explicit dependency

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -32,6 +32,7 @@
     "ink": "^5.2.1",
     "ink-spinner": "^5.0.0",
     "mppx": "^0.5.7",
+    "viem": "^2.47.5",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "update-notifier": "^7.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       update-notifier:
         specifier: ^7.3.1
         version: 7.3.1
+      viem:
+        specifier: ^2.47.5
+        version: 2.47.10(typescript@5.9.3)(zod@4.3.6)
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
Adding viem as an explicit dependency of the link-cli; viem is usually pulled in as a peer dependency via mppx, but this change makes this dependency explicit.

Will fix errors like those highlighted in https://github.com/stripe/link-cli/issues/60, where a package manager may not install peer dependencies by default.