### PR TITLE
Docs, skill improvements 2026-05-03

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Link CLI
 
-Link CLI lets agents get secure, one-time-use payment credentials from a Link wallet — so agents can complete purchases on your behalf without ever storing your real card details.
+Link CLI lets agents get secure, one-time-use payment credentials from a Link wallet to complete purchases on your behalf — without storing your real card details.
 
 The CLI can produce one of two credential types:
 
 - A virtual card (PAN) for use with a standard web checkout form. The issued card works anywhere, and is not restricted to Link-enabled sellers or sellers that use Stripe.
-- A [Shared Payment Token](https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens) (SPT) when the seller is in the Stripe Network and accepts payments programmatically (for example with [Machine Payment Protocols](https://mpp.dev) (MPP))
+- A [Shared Payment Token](https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens) (SPT) when the seller accepts programmatic payments through [Machine Payment Protocols](https://mpp.dev) (MPP)
 
 For now, this is only available to US Link accounts.
 
@@ -29,7 +29,7 @@ Install the skill:
 npx skills add stripe/link-cli
 ```
 
-By default when called from an agent (non-TTY), all commands use `toon` output. All commands accept `--format [format]` for structured output. Other formats: `json`, `yaml`, `md`, `jsonl`.
+By default when called from an agent (non-TTY), all commands use `toon` output — a compact, LLM-friendly text format. All commands accept `--format [format]` for structured output. Other formats: `json`, `yaml`, `md`, `jsonl`.
 
 List available commands:
 
@@ -74,7 +74,7 @@ The `link-cli` requires a Link account. You can log in to your existing one or [
 link-cli auth login
 ```
 
-You'll receive a verification URL and a short phrase. Visit the URL, log in to your Link account, and enter the phrase to approve the connection.
+You receive a verification URL and a short phrase. Visit the URL, log in to your Link account, and enter the phrase to approve the connection.
 
 ### List payment methods
 
@@ -82,11 +82,11 @@ You'll receive a verification URL and a short phrase. Visit the URL, log in to y
 link-cli payment-methods list
 ```
 
-Returns the cards and bank accounts saved to your Link account. Use the `id` field as `payment_method_id` in the next step. If you have no payment methods, you can [add new ones in Link](https://app.link.com/wallet).
+Returns the cards and bank accounts saved to your Link account. Use the `id` field as `payment_method_id` in the next step. If you have no payment methods, [add new ones in Link](https://app.link.com/wallet).
 
 ### Create a spend request
 
-To request a secure, one-time payment credential from your Link wallet, you create a spend request. You specify a payment method in your account, as well as some merchant details, line items, and amounts.
+Create a spend request with a payment method, merchant details, line items, and amounts:
 
 ```bash
 link-cli spend-request create \
@@ -123,7 +123,7 @@ Easily approve requests with the [Link app](https://link.com/download).
 
 #### Credential types
 
-By default, a spend request provisions a virtual card. For merchants that support the [Machine Payments Protocol](https://mpp.dev) (HTTP 402) and the Stripe payment method, you can instead include `--credential-type "shared_payment_token"`. 
+By default, a spend request provisions a virtual card. For merchants that support the [Machine Payments Protocol](https://mpp.dev) (HTTP 402) and the Stripe payment method, instead pass `--credential-type "shared_payment_token"`. 
 
 ### Execute payment
 
@@ -132,7 +132,7 @@ The approved spend request includes a `card` object with `number`, `cvc`, `exp_m
 ```bash
 link-cli spend-request retrieve lsrq_001
 ```
-By default, retrieving a spend request will not include card details. Use the `--include=card` to see unmasked card details.
+By default, retrieving a spend request doesn't include card details. Pass `--include card` to see unmasked card details.
 
 For agent polling, pass `--interval` and optionally `--max-attempts`:
 
@@ -161,7 +161,7 @@ link-cli auth status                               # check auth status
 link-cli auth logout                               # disconnect
 ```
 
-When `--client-name` is provided, the name is shown in the Link app when the user approves the connection — e.g. `Claude Code on my-macbook` instead of `link-cli on my-macbook`.
+When you provide `--client-name`, the Link app displays it when you approve the connection — for example, `Claude Code on my-macbook` instead of `link-cli on my-macbook`.
 
 `auth status` includes an `update` field when a newer version is available:
 
@@ -176,7 +176,7 @@ When `--client-name` is provided, the name is shown in the Link app when the use
 }
 ```
 
-Set `NO_UPDATE_NOTIFIER=1` to suppress update checks (e.g. in CI).
+Set `NO_UPDATE_NOTIFIER=1` to suppress update checks (for example, in CI).
 
 ### Spend request lifecycle
 
@@ -185,40 +185,37 @@ A spend request moves through: **create** → **request approval** → **approve
 **Required fields for create:** `payment_method_id`, `merchant_name`, `merchant_url`, `context`, `amount`
 
 **Constraints:** `context` must be at least 100 characters; `amount` must not exceed 50000 (cents); `currency` must be a 3-letter ISO code.
-**Test mode:** Pass `--test` to create testmode credentials (uses test card `4242424242424242`). Useful for development and integration testing without using real payment methods.
+**Test mode:** Pass `--test` to create testmode credentials (uses test card `4242424242424242`), useful for development and integration testing without real payment methods.
 
 ```bash
 # Update before approval
 link-cli spend-request update lsrq_001 \
-  --merchant-url https://press.stripe.com/working-in-public \
- 
+  --merchant-url https://press.stripe.com/working-in-public
 
 # Request approval separately (alternative to create --request-approval)
 link-cli spend-request request-approval lsrq_001
 
-# Retrieve at any time (includes card credentials once approved)
+# Retrieve at any time (includes card credentials after approval)
 link-cli spend-request retrieve lsrq_001
 ```
 
 ### MPP
 
-Use `mpp pay` to complete purchases on merchants that use the [Machine Payments Protocol](https://mpp.dev). The spend request must use `credential_type: "shared_payment_token"` and be approved. The SPT is one-time-use — if payment fails, create a new spend request.
+Use `mpp pay` to complete purchases on merchants that use the [Machine Payments Protocol](https://mpp.dev). The spend request must use `credential_type: "shared_payment_token"` and you must approve it before paying. The SPT is one-time-use — if payment fails, create a new spend request.
 
 ```bash
 link-cli mpp pay https://climate.stripe.dev/api/contribute \
   --spend-request-id lsrq_001 \
   --method POST \
   --data '{"amount":100}' \
-  --header "X-Custom: value" \
- 
+  --header "X-Custom: value"
 ```
 
 Use `mpp decode` to validate a raw `WWW-Authenticate` header and extract the `network_id` needed for `shared_payment_token` spend requests:
 
 ```bash
 link-cli mpp decode \
-  --challenge 'Payment id="ch_001", realm="merchant.example", method="stripe", intent="charge", request="..."' \
- 
+  --challenge 'Payment id="ch_001", realm="merchant.example", method="stripe", intent="charge", request="..."'
 ```
 
 ### Environment variables
@@ -231,7 +228,7 @@ link-cli mpp decode \
 
 ## Onboard
 
-Run the guided setup flow — authenticates, checks payment methods, shows the app download QR, and walks through both demo flows:
+Run the guided setup flow — authenticates, checks payment methods, shows the app download QR, and runs both demo flows:
 
 ```bash
 link-cli onboard

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Easily approve requests with the [Link app](https://link.com/download).
 --line-item "name:Running Shoes,unit_amount:12000,quantity:1,description:Trail runners"
 ```
 
-**`--total` keys:** `type` (required), `display_text` (required), `amount` (required)
+**`--total` keys:** `type` (required; one of: `subtotal`, `tax`, `total`), `display_text` (required), `amount` (required)
 
 ```bash
 --total "type:subtotal,display_text:Subtotal,amount:12000" \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Link CLI
 
-Link CLI lets agents get secure, one-time-use payment credentials from a Link wallet — so they can complete purchases on your behalf without ever storing your real card details.
+Link CLI lets agents get secure, one-time-use payment credentials from a Link wallet — so agents can complete purchases on your behalf without ever storing your real card details.
+
+The CLI can produce one of two credential types:
+
+- A virtual card (PAN) for use with a standard web checkout form. The issued card works anywhere, and is not restricted to Link-enabled sellers or sellers that use Stripe.
+- A [Shared Payment Token](https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens) (SPT) when the seller is in the Stripe Network and accepts payments programmatically (for example with [Machine Payment Protocols](https://mpp.dev) (MPP))
+
+For now, this is only available to US Link accounts.
 
 ## Installation
 
@@ -14,11 +21,31 @@ Or run directly with `npx`:
 npx @stripe/link-cli
 ```
 
-You can install the skill via `npx skills add stripe/link-cli`.
+### Use with agents
 
-### MCP Server
+Install the skill:
 
-Link CLI can also run as a local MCP server. Add the following to your MCP client config (`.mcp.json`, etc.)
+```bash
+npx skills add stripe/link-cli
+```
+
+By default when called from an agent (non-TTY), all commands use `toon` output. All commands accept `--format [format]` for structured output. Other formats: `json`, `yaml`, `md`, `jsonl`.
+
+List available commands:
+
+```bash
+link-cli --llms-full
+```
+
+Get a command's full schema with `--schema`. Example:
+
+```bash
+link-cli spend-request create --schema
+```
+
+#### MCP Server
+
+Link CLI can run as a local MCP server. Add the following to your MCP client config (`.mcp.json`, etc.)
 
 ```json
 {
@@ -32,6 +59,12 @@ Link CLI can also run as a local MCP server. Add the following to your MCP clien
 ```
 
 ## Quickstart
+
+Run a guided onboarding and demo flow:
+
+```bash
+link-cli onboard
+```
 
 ### Login
 
@@ -67,9 +100,9 @@ link-cli spend-request create \
   --request-approval
 ```
 
-The `--request-approval` flag triggers a push notification (or email) to the user for approval, then polls until the request is approved or denied.
+The `--request-approval` flag triggers a push notification to the user for approval, then polls until the request is approved or denied.
 
-Users can easily approve requests with the [Link app](https://link.com/download).
+Easily approve requests with the [Link app](https://link.com/download).
 
 #### Line items and totals
 
@@ -97,14 +130,14 @@ By default, a spend request provisions a virtual card. For merchants that suppor
 The approved spend request includes a `card` object with `number`, `cvc`, `exp_month`, `exp_year`, `billing_address`, and `valid_until`. Enter these into the merchant's checkout form. 
 
 ```bash
-link-cli spend-request retrieve lsrq_001 --format json
+link-cli spend-request retrieve lsrq_001
 ```
 By default, retrieving a spend request will not include card details. Use the `--include=card` to see unmasked card details.
 
 For agent polling, pass `--interval` and optionally `--max-attempts`:
 
 ```bash
-link-cli spend-request retrieve lsrq_001 --interval 2 --max-attempts 150 --format json
+link-cli spend-request retrieve lsrq_001 --interval 2 --max-attempts 150
 ```
 
 Polling exits successfully only after the request reaches a terminal status such as `approved`, `denied`, or `expired`. If polling reaches `--timeout` or exhausts `--max-attempts` while the request is still non-terminal, the command exits non-zero with `code: "POLLING_TIMEOUT"` so callers do not treat a still-pending request as complete.
@@ -115,8 +148,7 @@ If the merchant supports MPP, use `link-cli mpp pay` instead:
 link-cli mpp pay https://climate.stripe.dev/api/contribute \
   --spend-request-id lsrq_001 \
   --method POST \
-  --data '{"amount":100}' \
-  --format json
+  --data '{"amount":100}'
 ```
 
 ## Advanced
@@ -124,14 +156,14 @@ link-cli mpp pay https://climate.stripe.dev/api/contribute \
 ### Authentication
 
 ```bash
-link-cli auth login --client-name "Claude Code" --format json   # identify the connecting agent
-link-cli auth status --format json                               # check auth status
-link-cli auth logout --format json                               # disconnect
+link-cli auth login --client-name "Claude Code"   # identify the connecting agent
+link-cli auth status                               # check auth status
+link-cli auth logout                               # disconnect
 ```
 
 When `--client-name` is provided, the name is shown in the Link app when the user approves the connection — e.g. `Claude Code on my-macbook` instead of `link-cli on my-macbook`.
 
-`auth status --format json` includes an `update` field when a newer version is available:
+`auth status` includes an `update` field when a newer version is available:
 
 ```json
 {
@@ -159,18 +191,14 @@ A spend request moves through: **create** → **request approval** → **approve
 # Update before approval
 link-cli spend-request update lsrq_001 \
   --merchant-url https://press.stripe.com/working-in-public \
-  --format json
+ 
 
 # Request approval separately (alternative to create --request-approval)
-link-cli spend-request request-approval lsrq_001 --format json
+link-cli spend-request request-approval lsrq_001
 
 # Retrieve at any time (includes card credentials once approved)
-link-cli spend-request retrieve lsrq_001 --format json
+link-cli spend-request retrieve lsrq_001
 ```
-
-### Output formats
-
-All commands accept `--format json` for structured JSON output. Other formats: `yaml`, `md`, `jsonl`, `toon` (default). Errors are returned as JSON with `code` and `message` fields, with exit code 1.
 
 ### MPP
 
@@ -182,7 +210,7 @@ link-cli mpp pay https://climate.stripe.dev/api/contribute \
   --method POST \
   --data '{"amount":100}' \
   --header "X-Custom: value" \
-  --format json
+ 
 ```
 
 Use `mpp decode` to validate a raw `WWW-Authenticate` header and extract the `network_id` needed for `shared_payment_token` spend requests:
@@ -190,7 +218,7 @@ Use `mpp decode` to validate a raw `WWW-Authenticate` header and extract the `ne
 ```bash
 link-cli mpp decode \
   --challenge 'Payment id="ch_001", realm="merchant.example", method="stripe", intent="charge", request="..."' \
-  --format json
+ 
 ```
 
 ### Environment variables

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "biome lint .",
     "format": "biome format --write .",
     "check": "biome check --write .",
-    "link-cli": "node packages/cli/dist/cli.js"
+    "link-cli": "./packages/cli/dist/cli.js"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/link-cli",
-  "version": "0.4.2",
+  "version": "0.4.0",
   "type": "module",
   "bin": {
     "link-cli": "./dist/cli.js"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stripe/link-cli",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "type": "module",
   "bin": {
     "link-cli": "./dist/cli.js"

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -29,7 +29,6 @@ const notifier = updateNotifier({
   pkg: { name: cliName, version: cliVersion },
 });
 
-
 const cli = Cli.create('link-cli', {
   description:
     'Create a secure, one-time payment credential from a Link wallet to let agents complete purchases on behalf of users.',

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -29,6 +29,7 @@ const notifier = updateNotifier({
   pkg: { name: cliName, version: cliVersion },
 });
 
+
 const cli = Cli.create('link-cli', {
   description:
     'Create a secure, one-time payment credential from a Link wallet to let agents complete purchases on behalf of users.',

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -1,11 +1,15 @@
 import { Cli } from 'incur';
-import updateNotifier from 'update-notifier';
 import { createAuthCli } from './commands/auth';
 import { createDemoCli } from './commands/demo';
 import { createMppCli } from './commands/mpp';
 import { createOnboardCli } from './commands/onboard';
 import { createPaymentMethodsCli } from './commands/payment-methods';
 import { createSpendRequestCli } from './commands/spend-request';
+import {
+  createAgentUpdateInfoProvider,
+  createInteractiveUpdateInfoProvider,
+  renderInteractiveUpdateNotice,
+} from './utils/update-info';
 import { ResourceFactory } from './utils/resource-factory';
 
 declare const __CLI_VERSION__: string;
@@ -25,17 +29,26 @@ const factory = new ResourceFactory({ verbose, defaultHeaders });
 const authRepo = factory.createAuthResource();
 const spendRequestRepo = factory.createSpendRequestResource();
 
-const notifier = updateNotifier({
-  pkg: { name: cliName, version: cliVersion },
-});
-
 const cli = Cli.create('link-cli', {
   description:
     'Create a secure, one-time payment credential from a Link wallet to let agents complete purchases on behalf of users.',
   version: `${cliVersion} (build ${buildNumber})`,
 });
 
-cli.command(createAuthCli(authRepo, notifier.update));
+const isAgent =
+  process.argv.includes('--format') || process.argv.includes('--mcp');
+const agentUpdateInfoProvider = createAgentUpdateInfoProvider(cliVersion);
+let getUpdateInfo = agentUpdateInfoProvider;
+
+if (!isAgent && process.stdout.isTTY) {
+  const updateInfo = await agentUpdateInfoProvider({ polling: false });
+  getUpdateInfo = createInteractiveUpdateInfoProvider(updateInfo);
+  if (updateInfo) {
+    process.stderr.write(renderInteractiveUpdateNotice(updateInfo));
+  }
+}
+
+cli.command(createAuthCli(authRepo, getUpdateInfo));
 cli.command(createSpendRequestCli(spendRequestRepo));
 cli.command(
   createPaymentMethodsCli(() => factory.createPaymentMethodsResource()),
@@ -51,12 +64,6 @@ cli.command(
     factory.createPaymentMethodsResource(),
   ),
 );
-
-const isAgent =
-  process.argv.includes('--format') || process.argv.includes('--mcp');
-if (!isAgent) {
-  notifier.notify({ defer: false });
-}
 
 cli.serve();
 

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -5,12 +5,12 @@ import { createMppCli } from './commands/mpp';
 import { createOnboardCli } from './commands/onboard';
 import { createPaymentMethodsCli } from './commands/payment-methods';
 import { createSpendRequestCli } from './commands/spend-request';
+import { ResourceFactory } from './utils/resource-factory';
 import {
   createAgentUpdateInfoProvider,
   createInteractiveUpdateInfoProvider,
   renderInteractiveUpdateNotice,
 } from './utils/update-info';
-import { ResourceFactory } from './utils/resource-factory';
 
 declare const __CLI_VERSION__: string;
 declare const __BUILD_NUMBER__: string;

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -37,7 +37,10 @@ const cli = Cli.create('link-cli', {
 
 const isAgent =
   process.argv.includes('--format') || process.argv.includes('--mcp');
-const agentUpdateInfoProvider = createAgentUpdateInfoProvider(cliVersion);
+const agentUpdateInfoProvider = createAgentUpdateInfoProvider(
+  cliName,
+  cliVersion,
+);
 let getUpdateInfo = agentUpdateInfoProvider;
 
 if (!isAgent && process.stdout.isTTY) {

--- a/packages/cli/src/commands/auth/index.tsx
+++ b/packages/cli/src/commands/auth/index.tsx
@@ -3,6 +3,7 @@ import { Cli } from 'incur';
 import { render } from 'ink';
 import React from 'react';
 import type { IAuthResource } from '../../auth/types';
+import type { UpdateInfoProvider } from '../../utils/update-info';
 import { Login } from './login';
 import { Logout } from './logout';
 import { loginOptions, statusOptions } from './schema';
@@ -10,7 +11,7 @@ import { AuthStatus } from './status';
 
 export function createAuthCli(
   authResource: IAuthResource,
-  updateInfo?: { current: string; latest: string },
+  getUpdateInfo?: UpdateInfoProvider,
 ) {
   const cli = Cli.create('auth', {
     description: 'Authentication commands',
@@ -103,6 +104,21 @@ export function createAuthCli(
     options: statusOptions,
     outputPolicy: 'agent-only' as const,
     async *run(c) {
+      const opts = c.options;
+      const interval = opts.interval;
+      const maxAttempts = opts.maxAttempts;
+      const deadline = Date.now() + opts.timeout * 1000;
+      const updateInfo = await getUpdateInfo?.({
+        polling: interval > 0,
+      });
+      const update = updateInfo
+        ? {
+            current_version: updateInfo.current,
+            latest_version: updateInfo.latest,
+            update_command: 'npm install -g @stripe/link-cli',
+          }
+        : undefined;
+
       if (!c.agent && !c.formatExplicit) {
         return new Promise((resolve) => {
           const { waitUntilExit } = render(
@@ -119,15 +135,12 @@ export function createAuthCli(
                   }
                 : {}),
               credentials_path: storage.getPath(),
+              ...(update && { update }),
             });
           });
         });
       }
 
-      const opts = c.options;
-      const interval = opts.interval;
-      const maxAttempts = opts.maxAttempts;
-      const deadline = Date.now() + opts.timeout * 1000;
       let attempts = 0;
       let previousAttemptData: string | undefined;
 
@@ -143,13 +156,6 @@ export function createAuthCli(
         }
 
         const auth = storage.getAuth();
-        const update = updateInfo
-          ? {
-              current_version: updateInfo.current,
-              latest_version: updateInfo.latest,
-              update_command: 'npm install -g @stripe/link-cli',
-            }
-          : undefined;
         if (auth) {
           yield {
             authenticated: true,

--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -49,7 +49,7 @@ export const createOptions = z.object({
     .array(z.union([z.string(), z.record(z.string(), z.unknown())]))
     .default([])
     .describe(
-      'Total (repeatable, key:value format). Keys: type (required), display_text (required), amount (required). Example: "type:total,display_text:Total,amount:5000"',
+      'Total (repeatable, key:value format). Keys: type (required; one of: subtotal, tax, total), display_text (required), amount (required). Example: "type:total,display_text:Total,amount:5000"',
     ),
   requestApproval: z
     .boolean()
@@ -105,6 +105,6 @@ export const updateOptions = z.object({
     .array(z.union([z.string(), z.record(z.string(), z.unknown())]))
     .default([])
     .describe(
-      'Total (repeatable, key:value format). Keys: type (required), display_text (required), amount (required). Example: "type:total,display_text:Total,amount:5000"',
+      'Total (repeatable, key:value format). Keys: type (required; one of: subtotal, tax, total), display_text (required), amount (required). Example: "type:total,display_text:Total,amount:5000"',
     ),
 });

--- a/packages/cli/src/utils/update-info.ts
+++ b/packages/cli/src/utils/update-info.ts
@@ -1,0 +1,102 @@
+export interface UpdateInfo {
+  current: string;
+  latest: string;
+}
+
+export interface UpdateInfoRequest {
+  polling: boolean;
+}
+
+export type UpdateInfoProvider = (
+  request: UpdateInfoRequest,
+) => Promise<UpdateInfo | undefined>;
+
+const NPM_LATEST_URL = 'https://registry.npmjs.org/@stripe/link-cli/latest';
+const UPDATE_CACHE_TTL_MS = 60 * 60 * 1000;
+const FAILURE_CACHE_TTL_MS = 60 * 1000;
+const FETCH_TIMEOUT_MS = 5_000;
+
+let cachedUpdateInfo:
+  | {
+      expiresAt: number;
+      value?: UpdateInfo;
+    }
+  | undefined;
+let inflightUpdateInfo: Promise<UpdateInfo | undefined> | undefined;
+
+export function createAgentUpdateInfoProvider(
+  cliVersion: string,
+): UpdateInfoProvider {
+  return async ({ polling }) => {
+    if (polling) {
+      return cachedUpdateInfo?.value;
+    }
+
+    const now = Date.now();
+    if (cachedUpdateInfo && cachedUpdateInfo.expiresAt > now) {
+      return cachedUpdateInfo.value;
+    }
+
+    if (!inflightUpdateInfo) {
+      inflightUpdateInfo = fetchLatestVersion(cliVersion).finally(() => {
+        inflightUpdateInfo = undefined;
+      });
+    }
+
+    return inflightUpdateInfo;
+  };
+}
+
+export function createInteractiveUpdateInfoProvider(
+  updateInfo?: UpdateInfo,
+): UpdateInfoProvider {
+  return async () => updateInfo;
+}
+
+export function renderInteractiveUpdateNotice(updateInfo: UpdateInfo): string {
+  return [
+    '',
+    `Update available for @stripe/link-cli: ${updateInfo.current} -> ${updateInfo.latest}`,
+    'Run: npm install -g @stripe/link-cli',
+    '',
+  ].join('\n');
+}
+
+async function fetchLatestVersion(
+  cliVersion: string,
+): Promise<UpdateInfo | undefined> {
+  try {
+    const response = await fetch(NPM_LATEST_URL, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      cacheUpdateInfo(undefined, FAILURE_CACHE_TTL_MS);
+      return undefined;
+    }
+
+    const payload = (await response.json()) as { version?: unknown };
+    const latest =
+      typeof payload.version === 'string' ? payload.version.trim() : undefined;
+    const value =
+      latest && latest.length > 0 && latest !== cliVersion
+        ? { current: cliVersion, latest }
+        : undefined;
+
+    cacheUpdateInfo(value);
+    return value;
+  } catch {
+    cacheUpdateInfo(undefined, FAILURE_CACHE_TTL_MS);
+    return undefined;
+  }
+}
+
+function cacheUpdateInfo(
+  value: UpdateInfo | undefined,
+  ttlMs: number = UPDATE_CACHE_TTL_MS,
+) {
+  cachedUpdateInfo = {
+    expiresAt: Date.now() + ttlMs,
+    value,
+  };
+}

--- a/packages/cli/src/utils/update-info.ts
+++ b/packages/cli/src/utils/update-info.ts
@@ -1,3 +1,6 @@
+import process from 'node:process';
+import updateNotifier from 'update-notifier';
+
 export interface UpdateInfo {
   current: string;
   latest: string;
@@ -11,10 +14,8 @@ export type UpdateInfoProvider = (
   request: UpdateInfoRequest,
 ) => Promise<UpdateInfo | undefined>;
 
-const NPM_LATEST_URL = 'https://registry.npmjs.org/@stripe/link-cli/latest';
 const UPDATE_CACHE_TTL_MS = 60 * 60 * 1000;
 const FAILURE_CACHE_TTL_MS = 60 * 1000;
-const FETCH_TIMEOUT_MS = 5_000;
 
 let cachedUpdateInfo:
   | {
@@ -25,6 +26,7 @@ let cachedUpdateInfo:
 let inflightUpdateInfo: Promise<UpdateInfo | undefined> | undefined;
 
 export function createAgentUpdateInfoProvider(
+  packageName: string,
   cliVersion: string,
 ): UpdateInfoProvider {
   return async ({ polling }) => {
@@ -38,9 +40,11 @@ export function createAgentUpdateInfoProvider(
     }
 
     if (!inflightUpdateInfo) {
-      inflightUpdateInfo = fetchLatestVersion(cliVersion).finally(() => {
-        inflightUpdateInfo = undefined;
-      });
+      inflightUpdateInfo = fetchLatestVersion(packageName, cliVersion).finally(
+        () => {
+          inflightUpdateInfo = undefined;
+        },
+      );
     }
 
     return inflightUpdateInfo;
@@ -63,21 +67,21 @@ export function renderInteractiveUpdateNotice(updateInfo: UpdateInfo): string {
 }
 
 async function fetchLatestVersion(
+  packageName: string,
   cliVersion: string,
 ): Promise<UpdateInfo | undefined> {
-  try {
-    const response = await fetch(NPM_LATEST_URL, {
-      headers: { Accept: 'application/json' },
-      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-    });
-    if (!response.ok) {
-      cacheUpdateInfo(undefined, FAILURE_CACHE_TTL_MS);
-      return undefined;
-    }
+  const previousDisableFlag = process.env.NO_UPDATE_NOTIFIER;
 
-    const payload = (await response.json()) as { version?: unknown };
-    const latest =
-      typeof payload.version === 'string' ? payload.version.trim() : undefined;
+  try {
+    process.env.NO_UPDATE_NOTIFIER = '1';
+    const notifier = updateNotifier({
+      pkg: {
+        name: packageName,
+        version: cliVersion,
+      },
+    });
+    const payload = await notifier.fetchInfo();
+    const latest = payload.latest?.trim();
     const value =
       latest && latest.length > 0 && latest !== cliVersion
         ? { current: cliVersion, latest }
@@ -88,6 +92,12 @@ async function fetchLatestVersion(
   } catch {
     cacheUpdateInfo(undefined, FAILURE_CACHE_TTL_MS);
     return undefined;
+  } finally {
+    if (previousDisableFlag === undefined) {
+      process.env.NO_UPDATE_NOTIFIER = undefined;
+    } else {
+      process.env.NO_UPDATE_NOTIFIER = previousDisableFlag;
+    }
   }
 }
 

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -154,7 +154,7 @@ link-cli spend-request create \
 
 **`--line-item` keys:** `name` (required), `quantity`, `unit_amount`, `description`, `sku`, `url`, `image_url`, `product_url`. Repeatable for multiple items.
 
-**`--total` keys:** `type` (required), `display_text` (required), `amount` (required). Repeatable (e.g. subtotal + shipping + total).
+**`--total` keys:** `type` (required; one of: `subtotal`, `tax`, `total`), `display_text` (required), `amount` (required). Repeatable (e.g. subtotal + tax + total).
 
 Do not proceed to payment while the request is still `created` or `pending_approval`. If polling exits with `POLLING_TIMEOUT`, keep waiting or ask the user whether to continue polling. If they deny, ask for clarification what to do next.
 

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -7,7 +7,6 @@ allowed-tools:
  - Bash(npx:*)
  - Bash(npm:*)
 license: Complete terms in LICENSE
-version: 0.0.1
 metadata:
   author: stripe
   url: link.com/agents
@@ -24,47 +23,49 @@ metadata:
 user-invocable: true
 ---
 
-# Creating Payment Credentials
+# Create Payment Credential
 
-Use Link to get secure, one-time-use payment credentials from a Link wallet to complete purchases.
+Use [Link](https://link.com) to get secure, one-time-use payment credentials from a Link wallet to complete purchases.
 
-## Choosing how to call Link
+The CLI can produce one of two credential types:
+- A virtual card (PAN) for use with a standard web checkout form. The issued card works anywhere.
+- A Shared Payment Token (SPT) when the seller is in the Stripe Network and accepts payments programmatically (for example with Machine Paymnet Protocols).
 
-Link CLI can run as an **MCP server** or as a **standalone CLI**. Always prefer the MCP server when available — it avoids shell parsing issues and is the intended integration path.
+## Installing
 
-1. **Check for the MCP server first.** Look for a `link-cli` MCP server in your active MCP connections. If present, call its tools directly (e.g. `auth_status`, `auth_login`, `spend-request_create`, `payment-methods_list`, `mpp_pay`, `mpp_decode`).
-2. **Fall back to the CLI** only if the MCP server is not available. Install it with `npm install -g @stripe/link-cli`, then use the shell commands documented below.
+Install with `npm install -g @stripe/link-cli`
 
-The rest of this document shows CLI commands. When using the MCP server, map each command to its corresponding MCP tool — the parameters and behavior are identical.
+## Running commands
 
-| CLI command | MCP tool |
-|---|---|
-| `auth login` | `mcp__link-cli__auth_login` |
-| `auth logout` | `mcp__link-cli__auth_logout` |
-| `auth status` | `mcp__link-cli__auth_status` |
-| `spend-request create` | `mcp__link-cli__spend-request_create` |
-| `spend-request update` | `mcp__link-cli__spend-request_update` |
-| `spend-request retrieve` | `mcp__link-cli__spend-request_retrieve` |
-| `spend-request request-approval` | `mcp__link-cli__spend-request_request-approval` |
-| `payment-methods list` | `mcp__link-cli__payment-methods_list` |
-| `payment-methods add` | `mcp__link-cli__payment-methods_add` |
-| `mpp pay` | `mcp__link-cli__mpp_pay` |
-| `mpp decode` | `mcp__link-cli__mpp_decode` |
+Link CLI can run as an **MCP server** or as a **standalone CLI**.
 
-## Running commands (CLI fallback)
+**MCP:** Add the following to your MCP client config (`.mcp.json`, etc.)
 
-All commands support `--format json` for machine-readable output. Pass input via flags (run `link-cli <command> --help` to see full schema details, including all fields, types, and constraints).
+```json
+{
+  "mcpServers": {
+    "link": {
+      "command": "npx",
+      "args": ["@stripe/link-cli", "--mcp"]
+    }
+  }
+}
+```
 
-IMPORTANT: Run `auth login` with `run_in_background=true` (or `TaskOutput(task_id, block: false)`). It emits JSON to stdout before it exits, then keeps running while it polls for user action.
+Or run directly with `npx @stripe/link-cli@latest --mcp`.
 
-The agent-facing JSON contract is:
+Be sure to call `tools/list` to see all available MCP tools.
 
-- `auth login --format json`: first object contains `verification_url` and `phrase`; final object contains authentication result after approval succeeds
-- `spend-request create --request-approval --format json`: returns the created spend request immediately with an `_next.command` polling hint
-- `spend-request request-approval --format json`: returns the approval link immediately with an `_next.command` polling hint
-- `spend-request retrieve <id> --interval <seconds> --format json`: polls until the spend request reaches a terminal status, then returns the terminal spend request. It exits non-zero with `code: "POLLING_TIMEOUT"` if `--timeout` is reached or `--max-attempts` is exhausted while the request is still non-terminal.
+### Common commands/options
 
-For `auth login`, keep reading stdout until the process exits. For spend request approval, present the `approval_url` to the user and start the `_next.command` polling command immediately. The user MUST visit the verification or approval URL to continue, and you should always show that full URL in clear text.
+- List all commands: `link-cli --llms`
+- List all commands with parameters: `link-cli --llms-full`
+- Get a command's exact schema with `--schema`. E.g. `link-cli spend-request create --schema`
+- Multi-step commands return a `_next` action. For example, authenticating or creating a spend request will return a `_next.command` that must be run to complete the flow.
+- By default all output will be in `toon` format. Pass `--format [json|md|yaml]` to change output format.
+- Some commands will return a verification or approval URL. THESE must be presented to the user clearly for their action.
+
+_Recommended_: Run `link-cli --llms` to understand all the available commands. Pass `--schema` before invoking a command to understand it's parameteres and contraints.
 
 ## Core flow
 
@@ -81,7 +82,7 @@ Copy this checklist and track progress:
 Check auth status:
 
 ```bash
-link-cli auth status --format json
+link-cli auth status
 ```
 
 If the response includes an `update` field, a newer version of `link-cli` is available — run the `update_command` from that field to upgrade before proceeding.
@@ -89,10 +90,10 @@ If the response includes an `update` field, a newer version of `link-cli` is ava
 If not authenticated:
 
 ```bash
-link-cli auth login --client-name "<your-agent-name>" --format json
+link-cli auth login --client-name "<your-agent-name>"
 ```
 
-Replace `<your-agent-name>` with the name of your agent or application (e.g. `"Personal Assistant", "Shopping Bot"`). This name appears in the user's Link app when they approve the connection. Use a clear, unique, identifiable name. Display the url and phrase to the user, with the guidance "Please visit the following URL to approve secure access to Link.”
+Replace `<your-agent-name>` with the name of your agent or application (e.g. `"Personal Assistant", "Shopping Bot"`). This name appears in the user's Link app when they approve the connection. Use a clear, unique, identifiable name.
 
 DO NOT PROCEED until the user is authenticated with Link.
 
@@ -101,7 +102,7 @@ Always check the current authentication status before starting a new login flow 
 ### Step 2: Evaluate the merchant site BEFORE creating a spend request
 
 **CRITICAL** before calling `spend-request create` you must complete this checklist:
-1. Understand how the merchant accepts payments (cards or machine payments or other). **Do NOT default to `card` credential type. The merchant determines the credential type — you cannot know it without checking first. Skipping this step will produce a spend request with the wrong credential type.
+1. Understand how the merchant accepts payments (cards or machine payments or other). **Do NOT** default to `card` credential type. The merchant determines the credential type — you cannot know it without checking first. Skipping this step will produce a spend request with the wrong credential type.
 2. Have the final total amount needed. Inclusive of any shipping costs, taxes or other costs. Skipping this step will produce a spend request that does not cover the full amount needed, and will be rejected.
 3. Clear context and understanding of what the user is purchasing. Be sure to know sizes, colors, shipping options, etc. Skipping this step will produce a spend request that the user does not recognize or understand.
 
@@ -124,7 +125,7 @@ What you find determines which credential type to use:
 To derive `network_id`, use Link CLI's challenge decoder:
 
 ```bash
-link-cli mpp decode --challenge '<raw WWW-Authenticate header>' --format json
+link-cli mpp decode --challenge '<raw WWW-Authenticate header>'
 ```
 
 This validates the Stripe challenge, decodes the `request` payload, and returns both the extracted `network_id` and the decoded request JSON. Pass the full header exactly as received, even if it also contains non-Stripe or multiple `Payment` challenges.
@@ -134,7 +135,7 @@ This validates the Stripe challenge, decodes the `request` payload, and returns 
 Use the default payment method, unless the user explicitly asks to select a different one.
 
 ```bash
-link-cli payment-methods list --format json
+link-cli payment-methods list
 ```
 
 ### Step 4: Create the spend request with the right credential type
@@ -148,14 +149,14 @@ link-cli spend-request create \
   --merchant-url "<url>" \
   --line-item "name:<product>,unit_amount:<cents>,quantity:<n>" \
   --total "type:total,display_text:Total,amount:<cents>" \
-  --format json
+ 
 ```
 
 **`--line-item` keys:** `name` (required), `quantity`, `unit_amount`, `description`, `sku`, `url`, `image_url`, `product_url`. Repeatable for multiple items.
 
 **`--total` keys:** `type` (required), `display_text` (required), `amount` (required). Repeatable (e.g. subtotal + shipping + total).
 
-After creating or requesting approval for a spend request, run the returned `_next.command` to poll for the terminal status. Do not proceed to payment while the request is still `created` or `pending_approval`. If polling exits with `POLLING_TIMEOUT`, keep waiting or ask the user whether to continue polling. If they deny, ask for clarification what to do next.
+Do not proceed to payment while the request is still `created` or `pending_approval`. If polling exits with `POLLING_TIMEOUT`, keep waiting or ask the user whether to continue polling. If they deny, ask for clarification what to do next.
 
 Recommend the user approves with the [Link app](https://link.com/download). Show the download URL.
 
@@ -163,12 +164,12 @@ Recommend the user approves with the [Link app](https://link.com/download). Show
 
 ### Step 5: Complete payment
 
-**Card:** Run `link-cli spend-request retrieve <id> --include card --format json` to get the `card` object with `number`, `cvc`, `exp_month`, `exp_year`, `billing_address` (name, line1, line2, city, state, postal_code, country), and `valid_until` (unix timestamp — the card stops working after this time). Enter these details into the merchant's checkout form.
+**Card:** Run `link-cli spend-request retrieve <id> --include card` to get the `card` object with `number`, `cvc`, `exp_month`, `exp_year`, `billing_address` (name, line1, line2, city, state, postal_code, country), and `valid_until` (unix timestamp — the card stops working after this time). Enter these details into the merchant's checkout form.
 
 **SPT with 402 flow:** The SPT is **one-time use** — if the payment fails, you need a new spend request and new SPT.
 
 ```bash
-link-cli mpp pay <url> --spend-request-id <id> [--method POST] [--data '{"amount":100}'] [--header 'Name: Value'] --format json
+link-cli mpp pay <url> --spend-request-id <id> [--method POST] [--data '{"amount":100}'] [--header 'Name: Value']
 ```
 
 `mpp pay` handles the full 402 flow automatically: probes the URL, parses the `www-authenticate` header, builds the `Authorization: Payment` credential using the SPT, and retries.

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -65,7 +65,7 @@ Call `tools/list` to see all available MCP tools.
 - By default all output is in `toon` format. Pass `--format [json|md|yaml]` to change output format.
 - Some commands return a verification or approval URL. **These** must be presented to the user clearly for their action.
 
-_Recommended_: Run `link-cli --llms` to understand all the available commands. The `--llms` output is the canonical reference for parameter names, types, and valid values. Pass `--schema` before invoking a command to understand its parameters and constraints.
+_Recommended_: Run `link-cli --llms` to understand all the available commands. The `--llms-full` output is the canonical reference for parameter names, types, and valid values. Pass `--schema` before invoking a command to understand its parameters and constraints.
 
 ## Core flow
 

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -29,11 +29,11 @@ Use [Link](https://link.com) to get secure, one-time-use payment credentials fro
 
 The CLI can produce one of two credential types:
 - A virtual card (PAN) for use with a standard web checkout form. The issued card works anywhere.
-- A Shared Payment Token (SPT) when the seller is in the Stripe Network and accepts payments programmatically (for example with Machine Paymnet Protocols).
+- A Shared Payment Token (SPT) when the seller is in the Stripe Network and accepts payments programmatically (for example with Machine Payment Protocols).
 
 ## Installing
 
-Install with `npm install -g @stripe/link-cli`
+Install with `npm install -g @stripe/link-cli`. Or run directly with `npx @stripe/link-cli`.
 
 ## Running commands
 
@@ -52,20 +52,20 @@ Link CLI can run as an **MCP server** or as a **standalone CLI**.
 }
 ```
 
-Or run directly with `npx @stripe/link-cli@latest --mcp`.
+Run the MCP server directly with `npx @stripe/link-cli@latest --mcp`.
 
-Be sure to call `tools/list` to see all available MCP tools.
+Call `tools/list` to see all available MCP tools.
 
 ### Common commands/options
 
 - List all commands: `link-cli --llms`
 - List all commands with parameters: `link-cli --llms-full`
-- Get a command's exact schema with `--schema`. E.g. `link-cli spend-request create --schema`
-- Multi-step commands return a `_next` action. For example, authenticating or creating a spend request will return a `_next.command` that must be run to complete the flow.
-- By default all output will be in `toon` format. Pass `--format [json|md|yaml]` to change output format.
-- Some commands will return a verification or approval URL. THESE must be presented to the user clearly for their action.
+- Get a command's exact schema with `--schema`. For example, `link-cli spend-request create --schema`
+- Multi-step commands return a `_next` action. For example, authenticating or creating a spend request returns a `_next.command` that must be run to complete the flow.
+- By default all output is in `toon` format. Pass `--format [json|md|yaml]` to change output format.
+- Some commands return a verification or approval URL. **These** must be presented to the user clearly for their action.
 
-_Recommended_: Run `link-cli --llms` to understand all the available commands. Pass `--schema` before invoking a command to understand it's parameteres and contraints.
+_Recommended_: Run `link-cli --llms` to understand all the available commands. The `--llms` output is the canonical reference for parameter names, types, and valid values. Pass `--schema` before invoking a command to understand its parameters and constraints.
 
 ## Core flow
 
@@ -93,15 +93,15 @@ If not authenticated:
 link-cli auth login --client-name "<your-agent-name>"
 ```
 
-Replace `<your-agent-name>` with the name of your agent or application (e.g. `"Personal Assistant", "Shopping Bot"`). This name appears in the user's Link app when they approve the connection. Use a clear, unique, identifiable name.
+Replace `<your-agent-name>` with the name of your agent or application (for example, `"Personal Assistant"`, `"Shopping Bot"`). This name appears in the user's Link app when they approve the connection. Use a clear, unique, identifiable name.
 
 DO NOT PROCEED until the user is authenticated with Link.
 
-Always check the current authentication status before starting a new login flow - the user may already be logged in.
+Always check the current authentication status before starting a new login flow — the user might already be logged in.
 
 ### Step 2: Evaluate the merchant site BEFORE creating a spend request
 
-**CRITICAL** before calling `spend-request create` you must complete this checklist:
+**CRITICAL:** Before calling `spend-request create` you must complete this checklist:
 1. Understand how the merchant accepts payments (cards or machine payments or other). **Do NOT** default to `card` credential type. The merchant determines the credential type — you cannot know it without checking first. Skipping this step will produce a spend request with the wrong credential type.
 2. Have the final total amount needed. Inclusive of any shipping costs, taxes or other costs. Skipping this step will produce a spend request that does not cover the full amount needed, and will be rejected.
 3. Clear context and understanding of what the user is purchasing. Be sure to know sizes, colors, shipping options, etc. Skipping this step will produce a spend request that the user does not recognize or understand.
@@ -164,7 +164,7 @@ Recommend the user approves with the [Link app](https://link.com/download). Show
 
 ### Step 5: Complete payment
 
-**Card:** Run `link-cli spend-request retrieve <id> --include card` to get the `card` object with `number`, `cvc`, `exp_month`, `exp_year`, `billing_address` (name, line1, line2, city, state, postal_code, country), and `valid_until` (unix timestamp — the card stops working after this time). Enter these details into the merchant's checkout form.
+**Card:** Run `link-cli spend-request retrieve <id> --include card` to get the `card` object with `number`, `cvc`, `exp_month`, `exp_year`, `billing_address` (name, line1, line2, city, state, postal_code, country), and `valid_until` (Unix timestamp — the card stops working after this time). Enter these details into the merchant's checkout form.
 
 **SPT with 402 flow:** The SPT is **one-time use** — if the payment fails, you need a new spend request and new SPT.
 
@@ -193,7 +193,6 @@ All errors are output as JSON with `code` and `message` fields, with exit code 1
 | `verification-failed` in error body from `mpp pay` | SPT was already consumed (one-time use) | Create a new spend request with `credential_type: "shared_payment_token"` — do not retry with the same spend request ID |
 | `context` validation error on `spend-request create` | `context` field is under 100 characters | Rewrite `context` as a full sentence explaining what is being purchased and why; the user reads this when approving |
 | API rejects `merchant_name` or `merchant_url` | These fields are forbidden when `credential_type` is `shared_payment_token` | Remove both fields from the request; SPT flows identify the merchant via `network_id` instead |
-| Command hangs indefinitely | `auth login` or `spend-request create` run synchronously | Always run these commands with `run_in_background=true` — they block until the user acts, so synchronous execution freezes the agent |
 | Spend request approved but payment fails immediately | Wrong credential type for the merchant (e.g. `card` on a 402-only endpoint) | Go back to Step 2, re-evaluate the merchant, create a new spend request with the correct `credential_type` |
 | Auth token expired mid-session (exit code 1 during approval polling) | Token refresh failure during background polling | Re-authenticate with `auth login`, then retrieve the existing spend request or resume polling. Only create a new spend request if the original one expired, was denied, or its shared payment token was already consumed |
 


### PR DESCRIPTION
Updates readme and skill with all the latest feedback, for example:
1. Make clear that cards work anywhere (not just Link)
2. CLI supports toon format by default
3. CLI supports `--llms` and such for understanding commands
4. Remove overly verbose push towards MCP servers and hard-coded tool names
5. Stylistic updates per Stripe style guides (/dante)
6. Adds missing documentation for the `--totals`

And more.

Also corrects the update notifier behavior to correctly display updates in TTY and non-TTY modes.