### PR TITLE
feat: ship per-arch standalone binaries on each release

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,74 @@
+name: Release binaries
+
+# Triggers when a GitHub Release is published (changesets/action does this on
+# every npm publish). Builds standalone single-file binaries for every Stripe
+# Link CLI target and attaches them, plus a manifest.json with sha256s, to
+# the same release. Downstream consumers (Houston, OpenClaw, etc.) pin against
+# the manifest URL so they can bundle link-cli without an npm runtime.
+#
+# workflow_dispatch path is provided for manual rebuilds against a past tag.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to attach binaries to (e.g. @stripe/link-cli@0.4.2)
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          TAG="${{ github.event.release.tag_name || github.event.inputs.release_tag }}"
+          # Strip the @stripe/link-cli@ prefix changesets uses, leaving "0.4.2"
+          VERSION="${TAG##*@}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.10'
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm turbo run build
+
+      - name: Build binaries
+        run: |
+          for target in darwin-arm64 darwin-x64 linux-x64 windows-x64; do
+            bun run scripts/build-binary.ts "$target"
+          done
+
+      - name: Generate manifest
+        run: bun run scripts/generate-manifest.ts "${{ steps.tag.outputs.version }}"
+
+      - name: Attach binaries to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ steps.tag.outputs.tag }}" \
+            dist-bin/link-cli-darwin-arm64 \
+            dist-bin/link-cli-darwin-x64 \
+            dist-bin/link-cli-linux-x64 \
+            dist-bin/link-cli-windows-x64.exe \
+            dist-bin/manifest.json \
+            --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-bin/
 *.log
 *.tgz
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Or run directly with `npx`:
 npx @stripe/link-cli
 ```
 
+### Standalone binaries
+
+Each release also ships single-file standalone binaries for darwin-arm64, darwin-x64, linux-x64, and windows-x64. These do not require Node or npm at runtime and are intended for embedding inside other applications (desktop apps, CI runners, agent platforms).
+
+Download from the [latest release](https://github.com/stripe/link-cli/releases/latest), or pin a specific build via the per-release `manifest.json`:
+
+```
+https://github.com/stripe/link-cli/releases/download/<tag>/manifest.json
+```
+
+The manifest reports the `version`, file names, sha256 checksums, and download URLs for every target.
+
 ### Use with agents
 
 Install the skill:

--- a/scripts/build-binary.ts
+++ b/scripts/build-binary.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+/**
+ * Build a single-file standalone link-cli binary for the requested target.
+ *
+ * Usage:
+ *   bun run scripts/build-binary.ts <target>
+ *
+ * Targets: darwin-arm64 | darwin-x64 | linux-x64 | windows-x64
+ *
+ * Output is written to dist-bin/link-cli-<target>[.exe].
+ *
+ * The bundle entrypoint is the same packages/cli/dist/cli.js that tsup emits,
+ * so this script must run AFTER `pnpm turbo run build`.
+ *
+ * Two of ink's transitive dependencies are stubbed at bundle time:
+ * - react-devtools-core: only used when DEV=true; ink uses a dynamic import,
+ *   but tsup bundles the static reference inside ink/build/devtools.js, which
+ *   then breaks compile if the optional dep is not installed.
+ * - update-notifier: marked external in tsup config; replaced with a noop
+ *   so the standalone binary does not need the on-disk package present.
+ */
+import { mkdirSync } from 'node:fs';
+import type { BunPlugin } from 'bun';
+
+const TARGETS = {
+  'darwin-arm64': 'bun-darwin-arm64',
+  'darwin-x64': 'bun-darwin-x64',
+  'linux-x64': 'bun-linux-x64',
+  'windows-x64': 'bun-windows-x64',
+} as const;
+
+type Target = keyof typeof TARGETS;
+
+const stubPlugin: BunPlugin = {
+  name: 'stub-optional-deps',
+  setup(build) {
+    build.onResolve(
+      { filter: /^(react-devtools-core|update-notifier)$/ },
+      (args) => ({ path: args.path, namespace: 'stub' }),
+    );
+    build.onLoad({ filter: /.*/, namespace: 'stub' }, (args) => {
+      if (args.path === 'react-devtools-core') {
+        return {
+          contents: 'export default { connectToDevTools() {} };',
+          loader: 'js',
+        };
+      }
+      return {
+        contents:
+          'const noop = () => ({ notify: () => {} }); export default noop;',
+        loader: 'js',
+      };
+    });
+  },
+};
+
+const target = (process.argv[2] ?? 'darwin-arm64') as Target;
+const flag = TARGETS[target];
+if (!flag) {
+  console.error(`Unknown target: ${target}`);
+  console.error(`Valid targets: ${Object.keys(TARGETS).join(', ')}`);
+  process.exit(1);
+}
+
+mkdirSync('dist-bin', { recursive: true });
+
+const ext = target.startsWith('windows') ? '.exe' : '';
+const outfile = `./dist-bin/link-cli-${target}${ext}`;
+
+console.log(`Building ${flag} -> ${outfile}`);
+
+await Bun.build({
+  entrypoints: ['./packages/cli/dist/cli.js'],
+  // @ts-expect-error compile is a Bun.build option but not in the public types yet
+  compile: { target: flag, outfile },
+  plugins: [stubPlugin],
+  minify: true,
+});

--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -1,0 +1,51 @@
+#!/usr/bin/env bun
+/**
+ * Emit dist-bin/manifest.json with sha256 checksums + download URLs for every
+ * binary in dist-bin/. Consumed by release-binaries.yml after the binaries are
+ * built. Downstream consumers (Houston, etc.) pin against this manifest.
+ *
+ * Usage:
+ *   bun run scripts/generate-manifest.ts <version> [<base-url>]
+ *
+ * <base-url> defaults to the GitHub release download URL pattern.
+ */
+import { createHash } from 'node:crypto';
+import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const version = process.argv[2];
+if (!version) {
+  console.error(
+    'Usage: bun run scripts/generate-manifest.ts <version> [<base-url>]',
+  );
+  process.exit(1);
+}
+
+const baseUrl =
+  process.argv[3] ??
+  `https://github.com/stripe/link-cli/releases/download/${version}`;
+
+const distDir = 'dist-bin';
+const files = readdirSync(distDir).filter((f) => f.startsWith('link-cli-'));
+
+const binaries: Record<string, { file: string; sha256: string; url: string }> =
+  {};
+
+for (const file of files) {
+  const target = file.replace(/^link-cli-/, '').replace(/\.exe$/, '');
+  const buf = readFileSync(join(distDir, file));
+  const sha256 = createHash('sha256').update(buf).digest('hex');
+  binaries[target] = { file, sha256, url: `${baseUrl}/${file}` };
+}
+
+const manifest = {
+  version,
+  generated_at: new Date().toISOString(),
+  binaries,
+};
+
+writeFileSync(
+  join(distDir, 'manifest.json'),
+  `${JSON.stringify(manifest, null, 2)}\n`,
+);
+console.log(JSON.stringify(manifest, null, 2));

--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -5,9 +5,7 @@
  * built. Downstream consumers (Houston, etc.) pin against this manifest.
  *
  * Usage:
- *   bun run scripts/generate-manifest.ts <version> [<base-url>]
- *
- * <base-url> defaults to the GitHub release download URL pattern.
+ *   bun run scripts/generate-manifest.ts <version>
  */
 import { createHash } from 'node:crypto';
 import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
@@ -15,16 +13,11 @@ import { join } from 'node:path';
 
 const version = process.argv[2];
 if (!version) {
-  console.error(
-    'Usage: bun run scripts/generate-manifest.ts <version> [<base-url>]',
-  );
+  console.error('Usage: bun run scripts/generate-manifest.ts <version>');
   process.exit(1);
 }
 
-const baseUrl =
-  process.argv[3] ??
-  `https://github.com/stripe/link-cli/releases/download/${version}`;
-
+const baseUrl = `https://github.com/stripe/link-cli/releases/download/${version}`;
 const distDir = 'dist-bin';
 const files = readdirSync(distDir).filter((f) => f.startsWith('link-cli-'));
 


### PR DESCRIPTION
## Summary

Adds a release workflow that attaches single-file standalone `link-cli` binaries to every GitHub Release, plus a `manifest.json` with sha256 checksums and per-target download URLs. Targets: `darwin-arm64`, `darwin-x64`, `linux-x64`, `windows-x64`.

## Motivation

We're shipping [Houston](https://gethouston.ai) (a desktop platform for non-technical founders to run AI agents) with Link as a first-class payments surface. Houston bundles three CLIs today (`codex`, `composio`, `claude-code`); for each we download a signed binary from upstream, sha256-verify, sign + notarize alongside our `.app`, and stage it into `Contents/Resources/bin/`. That works well because each upstream ships per-arch standalone binaries.

`link-cli` only ships on npm. Bundling a non-Node binary today means owning a `bun build --compile` (or `pkg`) pipeline per consumer, which means every consumer hitting the same packaging edges (the [`react-devtools-core` resolution issue under ink](https://github.com/vadimdemedes/ink/issues/665), `update-notifier` external handling, viem's WASM + dynamic imports). Solving it once upstream is a much smaller surface than every agent platform doing it independently.

Tracking issue with full context: #72.

## What this PR does

1. **`scripts/build-binary.ts`**: invokes `Bun.build` against the existing `packages/cli/dist/cli.js` entrypoint, with a tiny in-process plugin that stubs two optional deps (`react-devtools-core` is dynamically loaded by ink only when `DEV=true`; `update-notifier` is already external in `tsup.config.ts`). Output: `dist-bin/link-cli-<target>[.exe]`.

2. **`scripts/generate-manifest.ts`**: walks `dist-bin/`, sha256s every binary, emits `manifest.json` with `version`, `generated_at`, and per-target `{ file, sha256, url }`.

3. **`.github/workflows/release-binaries.yml`**: triggers on `release.published` (the event `changesets/action` fires on every npm publish). On a single Ubuntu runner, builds all four targets via Bun cross-compile, generates the manifest, and uploads everything to the existing release via `gh release upload`. `workflow_dispatch` is provided for manual rebuilds against an existing tag.

4. **`README.md`**: short "Standalone binaries" section under Installation pointing at the latest release + the manifest URL pattern.

5. **`.gitignore`**: adds `dist-bin/`.

## Verification

Run locally on macOS arm64 (Bun 1.3.10, Node 22, pnpm 10.32):

```bash
pnpm install --frozen-lockfile
pnpm turbo run build
for t in darwin-arm64 darwin-x64 linux-x64 windows-x64; do
  bun run scripts/build-binary.ts $t
done
bun run scripts/generate-manifest.ts 0.4.2
```

Result on `darwin-arm64` host:
- All four targets compile; total time < 10s after `pnpm turbo run build`.
- `dist-bin/link-cli-darwin-arm64 --help` and `--version` work.
- `dist-bin/link-cli-darwin-arm64 mpp decode --challenge 'Payment id="ch_001", realm="merchant.example", method="stripe", intent="charge", request="..."'` runs the viem-backed challenge decoder successfully (validation reaches the per-field "amount: missing" check, which is the expected behavior for an incomplete test challenge).
- Sizes (minified): darwin-arm64 60 MB, darwin-x64 64 MB, linux-x64 101 MB, windows-x64 111 MB. Linux/Windows are heavier because Bun ships more runtime polyfills for non-host targets.

CI gauntlet on this branch passes locally:
- `pnpm biome check .` — clean (96 files)
- `pnpm turbo run typecheck` — pass
- `pnpm turbo run test` — 100/100 pass
- `pnpm turbo run build` — pass

## Notes

- I pinned Bun to `1.3.10` in the workflow to keep release outputs reproducible. Happy to change that to `latest` or whatever your team prefers.
- The script uses `// @ts-expect-error` on one line because the `compile` option is supported by `Bun.build` at runtime but not yet in the public TypeScript types.
- Stub plugin replaces module *contents*, not the import path, so the bundled output has no leftover references to either optional dep on disk.
- I haven't touched `release.yml` — the existing changesets-driven flow is unchanged. This new workflow is fully additive and runs after the release event the existing flow already produces.
- I'll sign the CLA on first comment.

## Future work (not in this PR)

- Lazy-load viem inside `mpp decode` so the static bundle is smaller for non-MPP users (mentioned in the tracking issue).
- Linux arm64 + Windows arm64 if there's demand. Bun supports both targets; happy to add in a follow-up.

🤖 Co-authored with [Claude Code](https://claude.com/claude-code).
