### PR TITLE
fix(sdk): check token expiry in isAuthenticated()

### DIFF
--- a/packages/sdk/src/utils/__tests__/auth-expiry.test.ts
+++ b/packages/sdk/src/utils/__tests__/auth-expiry.test.ts
@@ -1,0 +1,118 @@
+import { MemoryStorage } from '@/utils/storage';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const NOW = 1_000_000;
+
+describe('isAuthenticated() expiry guard', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns true for a valid, non-expired token', () => {
+    const authStorage = new MemoryStorage();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    authStorage.setAuth({
+      access_token: 'at_123',
+      refresh_token: 'rt_123',
+      expires_in: 60,
+      token_type: 'Bearer',
+    });
+
+    vi.setSystemTime(NOW + 30_000); // 30s in — still valid
+    expect(authStorage.isAuthenticated()).toBe(true);
+  });
+
+  it('returns false once the token has expired', () => {
+    const authStorage = new MemoryStorage();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    authStorage.setAuth({
+      access_token: 'at_123',
+      refresh_token: 'rt_123',
+      expires_in: 60,
+      token_type: 'Bearer',
+    });
+
+    expect(authStorage.isAuthenticated()).toBe(true);
+
+    vi.setSystemTime(NOW + 61_000); // 1s past expiry
+    expect(authStorage.isAuthenticated()).toBe(false);
+  });
+
+  it('returns false at the exact expiry moment (>= boundary)', () => {
+    const authStorage = new MemoryStorage();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    authStorage.setAuth({
+      access_token: 'at_123',
+      refresh_token: 'rt_123',
+      expires_in: 60,
+      token_type: 'Bearer',
+    });
+
+    vi.setSystemTime(NOW + 60_000); // exactly at expires_at
+    expect(authStorage.isAuthenticated()).toBe(false);
+  });
+
+  it('respects a pre-set expires_at over expires_in', () => {
+    // withComputedExpiry uses ?? so a supplied expires_at is preserved as-is.
+    // If the caller passes an already-expired timestamp the token must be
+    // rejected even if expires_in is large.
+    const authStorage = new MemoryStorage();
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000_000);
+
+    authStorage.setAuth({
+      access_token: 'at_123',
+      refresh_token: 'rt_123',
+      expires_in: 9999,
+      expires_at: 1_000_000, // already in the past
+      token_type: 'Bearer',
+    });
+
+    expect(authStorage.isAuthenticated()).toBe(false);
+  });
+
+  it('returns false after clearAuth()', () => {
+    const authStorage = new MemoryStorage();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    authStorage.setAuth({
+      access_token: 'at_123',
+      refresh_token: 'rt_123',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+
+    expect(authStorage.isAuthenticated()).toBe(true);
+    authStorage.clearAuth();
+    expect(authStorage.isAuthenticated()).toBe(false);
+  });
+
+  it('returns false after clearAll()', () => {
+    const authStorage = new MemoryStorage();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    authStorage.setAuth({
+      access_token: 'at_123',
+      refresh_token: 'rt_123',
+      expires_in: 3600,
+      token_type: 'Bearer',
+    });
+
+    expect(authStorage.isAuthenticated()).toBe(true);
+    authStorage.clearAll();
+    expect(authStorage.isAuthenticated()).toBe(false);
+  });
+
+  it('returns false if no token is stored', () => {
+    const authStorage = new MemoryStorage();
+    expect(authStorage.isAuthenticated()).toBe(false);
+  });
+});

--- a/packages/sdk/src/utils/storage.ts
+++ b/packages/sdk/src/utils/storage.ts
@@ -87,7 +87,10 @@ export class Storage implements AuthStorage {
   }
 
   isAuthenticated(): boolean {
-    return this.getAuth() !== null;
+    const auth = this.getAuth();
+    if (!auth) return false;
+    if (auth.expires_at && Date.now() >= auth.expires_at) return false;
+    return true;
   }
 
   getPendingDeviceAuth(): PendingDeviceAuth | null {
@@ -130,6 +133,10 @@ export class MemoryStorage implements AuthStorage {
   private pendingAuth: PendingDeviceAuth | null = null;
 
   constructor(initialAuth: AuthTokens | null = null) {
+    // withComputedExpiry stamps expires_at with Date.now() at construction time.
+    // In tests that use vi.useFakeTimers(), call setAuth() *after* installing
+    // fake timers rather than passing initialAuth here, otherwise expires_at
+    // will be computed from real wall-clock time, not the mocked value.
     this.auth = initialAuth ? withComputedExpiry(initialAuth) : null;
   }
 
@@ -146,7 +153,10 @@ export class MemoryStorage implements AuthStorage {
   }
 
   isAuthenticated(): boolean {
-    return this.auth !== null;
+    const auth = this.getAuth();
+    if (!auth) return false;
+    if (auth.expires_at && Date.now() >= auth.expires_at) return false;
+    return true;
   }
 
   getPendingDeviceAuth(): PendingDeviceAuth | null {


### PR DESCRIPTION
### summary

identified and fixed a bug where `isAuthenticated()` in `storage.ts` returned `true` for expired tokens. expired sessions were treated as valid until the next API call returned a 401 meaning that any auth-gated command would proceed assuming a valid token.

### changes made

- updated `isAuthenticated()` in both `Storage` and `MemoryStorage` to check `auth.expires_at` against `Date.now()` returning `false` if the token has expired.
- added `packages/sdk/src/utils/__tests__/auth-expiry.test.ts` covering: valid tokens, expired tokens, the exact expiry boundary (`>=`), pre-set `expires_at` taking precedence over `expires_in` and both `clearAuth()` and `clearAll()` resetting authenticated state.
- also added a constructor comment to `MemoryStorage` warning that `withComputedExpiry` stamps `expires_at` at construction time, so tests using `vi.useFakeTimers()` should call `setAuth()` after installing fake timers rather than passing `initialAuth` directly.

### testing

- ran `npx turbo run test --filter @stripe/link-sdk` (all pass).
- verified formatting and linting with `biome check`.