### PR TITLE
fix: swallowing mpp errors

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1041,7 +1041,7 @@ describe('production mode', () => {
       expect(merchantRequests[1].headers.authorization).toMatch(/^Payment /);
     });
 
-    it('exits 1 when the paid retry fails', async () => {
+    it('returns structured response when the paid retry fails', async () => {
       setNextResponse(200, APPROVED_SPT_REQUEST);
       setMerchantResponse(402, '{"error":"payment required"}', {
         'www-authenticate': WWW_AUTHENTICATE_STRIPE,
@@ -1058,12 +1058,14 @@ describe('production mode', () => {
         'json',
       );
 
-      expect(result.exitCode).toBe(1);
-      const err = parseJson(result.stdout) as { message: string };
-      expect(err.message).toContain(
-        'Payment submission failed with status 401',
-      );
-      expect(err.message).toContain('spt rejected');
+      expect(result.exitCode).toBe(0);
+      const parsed = parseJson(result.stdout) as {
+        status: number;
+        headers: Record<string, string>;
+        body: string;
+      };
+      expect(parsed.status).toBe(401);
+      expect(parsed.body).toContain('spt rejected');
       expect(merchantRequests).toHaveLength(2);
     });
 

--- a/packages/cli/src/commands/mpp/pay.tsx
+++ b/packages/cli/src/commands/mpp/pay.tsx
@@ -31,19 +31,9 @@ function buildHeaders(
   return result;
 }
 
-async function readPayResult(
-  response: Response,
-  options?: { failOnError?: boolean },
-): Promise<PayResult> {
+async function readPayResult(response: Response): Promise<PayResult> {
   const responseHeaders = Object.fromEntries(response.headers.entries());
   const body = await response.text();
-
-  if (options?.failOnError && !response.ok) {
-    throw new Error(
-      `Payment submission failed with status ${response.status}: ${body}`,
-    );
-  }
-
   return { status: response.status, headers: responseHeaders, body };
 }
 
@@ -139,7 +129,7 @@ export async function runMppPay(
     },
   });
 
-  return readPayResult(retryResponse, { failOnError: true });
+  return readPayResult(retryResponse);
 }
 
 type Step = 'retrieving' | 'probing' | 'signing' | 'submitting' | 'done';
@@ -226,9 +216,7 @@ export function MppPay({
           },
         });
 
-        const payResult = await readPayResult(retryResponse, {
-          failOnError: true,
-        });
+        const payResult = await readPayResult(retryResponse);
         setResult(payResult);
         setStep('done');
         onComplete(payResult);
@@ -262,7 +250,17 @@ export function MppPay({
       )}
       {result && (
         <Box flexDirection="column">
-          <Text color="green">HTTP {result.status}</Text>
+          <Text
+            color={
+              result.status >= 400
+                ? 'red'
+                : result.status >= 300
+                  ? 'yellow'
+                  : 'green'
+            }
+          >
+            HTTP {result.status}
+          </Text>
           <Text>{result.body}</Text>
         </Box>
       )}


### PR DESCRIPTION
Issue: mpp pay returns structured { status, headers, body } when the initial probe gets a non-402 response, but throws a plain error on the settlement-retry (second request after the 402 handshake). The throw flattens status, headers, and body into a single error
  message string, making it impossible for agents to parse the merchant's response programmatically.

Root cause: readPayResult(response, { failOnError: true }) on the retry path throws on non-2xx instead of returning the structured envelope.

Fix: Removed failOnError entirely. The retry path now returns { status, headers, body } for all HTTP responses, matching the probe path's behavior. The agent inspects status to determine the outcome.