### PR TITLE
fix: CLI Approval Polling Bugs (surfaced by #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The file is created with `0600` permissions. If the file already exists, the com
 For agent polling, pass `--interval` and optionally `--max-attempts`:
 
 ```bash
-link-cli spend-request retrieve lsrq_001 --interval 2 --max-attempts 150
+link-cli spend-request retrieve lsrq_001 --interval 2 --max-attempts 300
 ```
 
 Polling exits successfully only after the request reaches a terminal status such as `approved`, `denied`, `expired`, or `canceled`. If polling reaches `--timeout` or exhausts `--max-attempts` while the request is still non-terminal, the command exits non-zero with `code: "POLLING_TIMEOUT"` so callers do not treat a still-pending request as complete.

--- a/packages/cli/src/commands/demo/card-flow.tsx
+++ b/packages/cli/src/commands/demo/card-flow.tsx
@@ -189,7 +189,12 @@ export const CardFlow: React.FC<CardFlowProps> = ({
         setStep('await-approval');
         for (;;) {
           try {
-            await pollUntilApproved(spendRequestRepo, result.id);
+            const final = await pollUntilApproved(spendRequestRepo, result.id);
+            if (final.status !== 'approved') {
+              throw new Error(
+                `Spend request did not reach approved (status: ${final.status})`,
+              );
+            }
             break;
           } catch (err) {
             if ((err as Error).message === 'Approval polling timed out') {

--- a/packages/cli/src/commands/demo/spt-flow.tsx
+++ b/packages/cli/src/commands/demo/spt-flow.tsx
@@ -187,6 +187,11 @@ export const SptFlow: React.FC<SptFlowProps> = ({
               spendRequestRepo,
               result.id,
             );
+            if (approved.status !== 'approved') {
+              throw new Error(
+                `Spend request did not reach approved (status: ${approved.status})`,
+              );
+            }
             setSpendRequest(approved);
             break;
           } catch (err) {

--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -171,9 +171,9 @@ export function createSpendRequestCli(
       }
       yield {
         ...created,
-        instruction: `Present the approval_url to the user and ask them to approve in the Link app. Then call \`spend-request retrieve ${created.id} --interval 2 --max-attempts 150\` to poll until approved. Do not wait for the user to reply — start polling immediately.`,
+        instruction: `Present the approval_url to the user and ask them to approve in the Link app. Then call \`spend-request retrieve ${created.id} --interval 2 --max-attempts 300\` to poll until approved. Do not wait for the user to reply — start polling immediately.`,
         _next: {
-          command: `spend-request retrieve ${created.id} --interval 2 --max-attempts 150`,
+          command: `spend-request retrieve ${created.id} --interval 2 --max-attempts 300`,
           until: 'status changes from pending_approval',
         },
       };
@@ -267,9 +267,9 @@ export function createSpendRequestCli(
       const approval = await repository.requestApproval(id);
       yield {
         ...approval,
-        instruction: `Present the approval_url to the user and ask them to approve in the Link app. Then call \`spend-request retrieve ${id} --interval 2 --max-attempts 150\` to poll until approved. Do not wait for the user to reply — start polling immediately.`,
+        instruction: `Present the approval_url to the user and ask them to approve in the Link app. Then call \`spend-request retrieve ${id} --interval 2 --max-attempts 300\` to poll until approved. Do not wait for the user to reply — start polling immediately.`,
         _next: {
-          command: `spend-request retrieve ${id} --interval 2 --max-attempts 150`,
+          command: `spend-request retrieve ${id} --interval 2 --max-attempts 300`,
           until: 'status changes from pending_approval',
         },
       };

--- a/packages/cli/src/commands/spend-request/retrieve.tsx
+++ b/packages/cli/src/commands/spend-request/retrieve.tsx
@@ -21,13 +21,26 @@ type Phase =
   | 'polling'
   | 'success'
   | 'declined'
+  | 'finalized'
   | 'timeout'
   | 'error';
+
+// Statuses past which polling should stop. Mirrors the JSON path in
+// commands/spend-request/index.tsx so an `expired`/`canceled`/`failed` request
+// doesn't keep the TUI spinning until the local timeout fires.
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set([
+  'approved',
+  'denied',
+  'expired',
+  'succeeded',
+  'failed',
+  'canceled',
+]);
 
 export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
   repository,
   id,
-  timeout = 300,
+  timeout = 600,
   include,
   outputFile,
   force,
@@ -87,6 +100,9 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
         } else if (result.status === 'denied') {
           setPhase('declined');
           setTimeout(() => onComplete(result), DISPLAY_DELAY_MS);
+        } else if (TERMINAL_STATUSES.has(result.status)) {
+          setPhase('finalized');
+          setTimeout(() => onComplete(result), DISPLAY_DELAY_MS);
         } else {
           startTimeRef.current = Date.now();
           setPhase('polling');
@@ -135,6 +151,11 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
           if (pollRef.current) clearInterval(pollRef.current);
           if (timerRef.current) clearInterval(timerRef.current);
           setPhase('declined');
+          setTimeout(() => onComplete(result), DISPLAY_DELAY_MS);
+        } else if (TERMINAL_STATUSES.has(result.status)) {
+          if (pollRef.current) clearInterval(pollRef.current);
+          if (timerRef.current) clearInterval(timerRef.current);
+          setPhase('finalized');
           setTimeout(() => onComplete(result), DISPLAY_DELAY_MS);
         }
       } catch {
@@ -201,6 +222,24 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
             </Text>
           </Box>
         )}
+      </Box>
+    );
+  }
+
+  if (phase === 'finalized') {
+    return (
+      <Box flexDirection="column">
+        <Text color="yellow">
+          Spend request reached terminal status: {request?.status}
+        </Text>
+        <Box flexDirection="column" marginTop={1} paddingX={2}>
+          <Text>
+            ID: <Text bold>{request?.id}</Text>
+          </Text>
+          <Text>
+            Status: <Text bold>{request?.status}</Text>
+          </Text>
+        </Box>
       </Box>
     );
   }

--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -76,9 +76,9 @@ export const createOptions = z.object({
 export const retrieveOptions = z.object({
   timeout: z.coerce
     .number()
-    .default(300)
+    .default(600)
     .describe(
-      'Polling timeout in seconds. When reached during active polling, exits non-zero with POLLING_TIMEOUT.',
+      'Polling timeout in seconds. When reached during active polling, exits non-zero with POLLING_TIMEOUT. Default exceeds the server-side spend-request expiry so polling outlives the request itself.',
     ),
   interval: z.coerce
     .number()

--- a/packages/cli/src/commands/spend-request/use-approval-polling.ts
+++ b/packages/cli/src/commands/spend-request/use-approval-polling.ts
@@ -51,11 +51,18 @@ export function useApprovalPolling({
     const poll = async () => {
       try {
         const final = await pollUntilApproved(repository, requestId);
-        if (!cancelled) {
-          onSuccess(final);
-          setStatus('success');
+        if (cancelled) return;
+        if (final.status !== 'approved') {
+          onError(
+            `Spend request did not reach approved (status: ${final.status})`,
+          );
+          setStatus('error');
           setTimeout(() => onComplete(final), DISPLAY_DELAY_MS);
+          return;
         }
+        onSuccess(final);
+        setStatus('success');
+        setTimeout(() => onComplete(final), DISPLAY_DELAY_MS);
       } catch (err) {
         if (!cancelled) {
           onError((err as Error).message);


### PR DESCRIPTION
## Summary

Addresses CLI-side issues surfaced by #63 (spend-request approval flow getting stuck on `pending_approval`).

> **Note:** The reported web-UI failure at `app.link.com/activity/approve/...` is server-side and outside this repo. However, investigating it surfaced three real bugs in the CLI's polling code worth fixing independently. Two focused commits, no API changes.

---

## What's Fixed

### 1. Recognize All Terminal Statuses in Approval Polling

The interactive `spend-request retrieve` TUI only treated `approved` and `denied` as terminal statuses. Any other terminal status — `expired`, `succeeded`, `failed`, `canceled` — caused continued polling until the local timeout fired, ultimately surfacing a misleading **"Timed out waiting for approval"** error for requests that had already reached a terminal state on the server.

The same misclassification affected:
- The `useApprovalPolling` hook (used by interactive `create` and `request-approval`)
- Both `demo` flows (`demo/card-flow`, `demo/spt-flow`)

In all of these, `pollUntilApproved` resolves on any non-pending terminal status (per its own unit-test contract), but every call site treated resolution as success — meaning a denied or expired request was rendered as **"✓ Spend request approved"**.

**Fix:** Introduced a shared `TERMINAL_STATUSES` set in the TUI (mirroring the JSON path's set in `commands/spend-request/index.tsx`) with a new `'finalized'` render branch. Added explicit `status === 'approved'` checks in `useApprovalPolling`, `demo/card-flow`, and `demo/spt-flow`.

> `pollUntilApproved` itself is unchanged — its tests assert the current contract, and the right fix is at the call sites.

---

### 2. Extend Default Polling Window Past Server-Side Expiry

The Link approval UI shows an ~8-minute expiry countdown, but `retrieveOptions.timeout` defaulted to **300 s**, and the `_next.command` hint emitted by `create`/`request-approval` recommended `--interval 2 --max-attempts 150` (also 300 s).

Users or agents racing the 8-minute window could hit `POLLING_TIMEOUT` purely because the CLI gave up before the request itself expired.

**Fix:**
- Bumped `--timeout` default to **600 s**
- Updated `_next.command` hint to `--max-attempts 300`
- Updated matching README example

Polling now comfortably outlives the server-side expiry. No effect when callers pass explicit values.

---

## What's Not Fixed (and Why)

The root cause of #63 — clicking **"Approve"** in the Link web app and the UI silently failing to transition the request out of `pending_approval` — occurs in the Link web application, which is not in this repository.

The CLI faithfully reports whatever status the API returns; only the API can advance the state machine. These changes fix adjacent CLI bugs that became visible because of the incident, not the incident's root cause itself.

---

## Test Plan

| Check | Result |
|---|---|
| `pnpm typecheck` | ✅ 3/3 packages clean |
| `pnpm test` | ✅ 204/204 tests pass (91 SDK + 113 CLI) |
| `pnpm biome check .` | ✅ Clean |

Relevant test coverage: `packages/cli/src/__tests__/cli.test.ts:711–781` — exercises `--max-attempts` exhaustion, `--timeout` expiry, and terminal-status detection in JSON-mode polling integration tests.