### PR TITLE
ci: declare contents:read on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The CI workflow installs pnpm, runs turbo build, biome, tests, and `pnpm publish --dry-run`. It never writes to the repo or comments on PRs. Right now it doesn't declare a `permissions:` block, so the workflow token gets whatever scope the repository default grants it.

Setting `permissions: contents: read` pins that to the minimum the steps actually use. Pattern matches:

- release.yml -- workflow-level `contents: write` + `pull-requests: write` + `id-token: write` for changesets
- issue-triggered-create-jira.yml -- workflow-level `contents: read`

So the same shape is already idiomatic here, just missing on ci.yml.

Third-party actions (`pnpm/action-setup`, `actions/setup-node`) are involved; capping the token narrows the blast radius if either is ever compromised (cf. tj-actions/changed-files CVE-2025-30066).