### PR TITLE
feat(sdk): add WebBotAuthResource for Web Bot Auth header minting

### DIFF
--- a/packages/cli/src/utils/__tests__/resource-factory.test.ts
+++ b/packages/cli/src/utils/__tests__/resource-factory.test.ts
@@ -1,4 +1,8 @@
-import { PaymentMethodsResource, SpendRequestResource } from '@stripe/link-sdk';
+import {
+  PaymentMethodsResource,
+  SpendRequestResource,
+  WebBotAuthResource,
+} from '@stripe/link-sdk';
 import { describe, expect, it } from 'vitest';
 import { LinkAuthResource } from '../../auth/auth-resource';
 import { ResourceFactory } from '../resource-factory';
@@ -14,12 +18,18 @@ describe('ResourceFactory', () => {
     expect(factory.createPaymentMethodsResource()).toBe(
       factory.createPaymentMethodsResource(),
     );
+    expect(factory.createWebBotAuthResource()).toBe(
+      factory.createWebBotAuthResource(),
+    );
     expect(factory.createAuthResource()).toBeInstanceOf(LinkAuthResource);
     expect(factory.createSpendRequestResource()).toBeInstanceOf(
       SpendRequestResource,
     );
     expect(factory.createPaymentMethodsResource()).toBeInstanceOf(
       PaymentMethodsResource,
+    );
+    expect(factory.createWebBotAuthResource()).toBeInstanceOf(
+      WebBotAuthResource,
     );
   });
 });

--- a/packages/cli/src/utils/resource-factory.ts
+++ b/packages/cli/src/utils/resource-factory.ts
@@ -4,10 +4,12 @@ import {
   type IShippingAddressResource,
   type ISpendRequestResource,
   type IUserInfoResource,
+  type IWebBotAuthResource,
   PaymentMethodsResource,
   ShippingAddressResource,
   SpendRequestResource,
   UserInfoResource,
+  WebBotAuthResource,
 } from '@stripe/link-sdk';
 import { LinkAuthResource } from '../auth/auth-resource';
 import { createAccessTokenProvider } from '../auth/session';
@@ -67,6 +69,7 @@ export class ResourceFactory {
   private paymentMethodsResource?: IPaymentMethodsResource;
   private shippingAddressResource?: IShippingAddressResource;
   private userInfoResource?: IUserInfoResource;
+  private webBotAuthResource?: IWebBotAuthResource;
 
   constructor(options: ResourceFactoryOptions = {}) {
     this.verbose = options.verbose ?? false;
@@ -169,5 +172,22 @@ export class ResourceFactory {
     );
 
     return this.userInfoResource;
+  }
+
+  createWebBotAuthResource(): IWebBotAuthResource {
+    if (this.webBotAuthResource) {
+      return this.webBotAuthResource;
+    }
+
+    const getAccessToken = this.createSdkAccessTokenProvider();
+    this.webBotAuthResource = sanitizeResource(
+      new WebBotAuthResource({
+        verbose: this.verbose,
+        defaultHeaders: this.defaultHeaders,
+        getAccessToken,
+      }),
+    );
+
+    return this.webBotAuthResource;
   }
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,6 +9,7 @@ export * from './resources/spend-request';
 export * from './resources/payment-methods';
 export * from './resources/shipping-address';
 export * from './resources/user-info';
+export * from './resources/web-bot-auth';
 export { MemoryStorage, Storage, storage } from './utils/storage';
 export type {
   AuthStorage,

--- a/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
+++ b/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
@@ -1,0 +1,167 @@
+import type { WebBotAuthBlock } from '@/types/index';
+import { WebBotAuthResource } from '@/resources/web-bot-auth';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockFetch = vi.fn();
+const getAccessToken = vi.fn();
+
+function mockFetchResponse(status: number, body: Record<string, unknown>) {
+  mockFetch.mockResolvedValue({
+    status,
+    text: async () => JSON.stringify(body),
+  });
+}
+
+const validUrl = 'https://wine-merchant.com/products';
+
+const webBotAuthBlock: WebBotAuthBlock = {
+  signature: 'sig1=:stub_sig:',
+  signature_input:
+    'sig1=("@authority" "signature-agent");created=1715400000;keyid="stub_keyid";alg="ed25519";expires=1715400600;tag="web-bot-auth"',
+  signature_agent:
+    'https://api.link.com/.well-known/http-message-signatures-directory',
+  authority: 'wine-merchant.com',
+  expires_at: '2099-12-31T23:59:59Z',
+};
+
+const credentialsResponse = {
+  identity_token: 'tok_test123',
+  web_bot_auth: webBotAuthBlock,
+};
+
+describe('WebBotAuthResource', () => {
+  let resource: WebBotAuthResource;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    vi.clearAllMocks();
+    getAccessToken.mockResolvedValue('test_token');
+    resource = new WebBotAuthResource({ getAccessToken });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('getHeaders', () => {
+    it('sends POST to credentials endpoint with JSON body and Bearer auth', async () => {
+      mockFetchResponse(200, credentialsResponse);
+
+      await resource.getHeaders(validUrl);
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://api.link.com/v1/agent_identity/credentials');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers['Content-Type']).toBe('application/json');
+      expect(opts.headers.Authorization).toBe('Bearer test_token');
+      expect(JSON.parse(opts.body)).toEqual({ url: validUrl });
+    });
+
+    it('returns the web_bot_auth block on success', async () => {
+      mockFetchResponse(200, credentialsResponse);
+
+      const result = await resource.getHeaders(validUrl);
+
+      expect(result).toEqual(webBotAuthBlock);
+    });
+
+    it('caches result per authority and skips re-fetch for same hostname', async () => {
+      mockFetchResponse(200, credentialsResponse);
+
+      const first = await resource.getHeaders(validUrl);
+      const second = await resource.getHeaders(
+        'https://wine-merchant.com/other-page',
+      );
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(second).toEqual(first);
+    });
+
+    it('does not share cache across different authorities', async () => {
+      mockFetchResponse(200, credentialsResponse);
+      await resource.getHeaders(validUrl);
+
+      mockFetchResponse(200, credentialsResponse);
+      await resource.getHeaders('https://other-merchant.com/page');
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('re-fetches when cached entry expires within the 30s buffer', async () => {
+      const nearlyExpiredBlock: WebBotAuthBlock = {
+        ...webBotAuthBlock,
+        expires_at: new Date(Date.now() + 20_000).toISOString(),
+      };
+      mockFetchResponse(200, {
+        ...credentialsResponse,
+        web_bot_auth: nearlyExpiredBlock,
+      });
+
+      await resource.getHeaders(validUrl);
+
+      mockFetchResponse(200, credentialsResponse);
+      await resource.getHeaders(validUrl);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not re-fetch when cached entry is still fresh', async () => {
+      mockFetchResponse(200, credentialsResponse);
+
+      await resource.getHeaders(validUrl);
+      await resource.getHeaders(validUrl);
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it('retries with refreshed token on 401', async () => {
+      mockFetch
+        .mockResolvedValueOnce({ status: 401, text: async () => '{}' })
+        .mockResolvedValueOnce({
+          status: 200,
+          text: async () => JSON.stringify(credentialsResponse),
+        });
+      getAccessToken
+        .mockResolvedValueOnce('expired_token')
+        .mockResolvedValueOnce('fresh_token');
+
+      const result = await resource.getHeaders(validUrl);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      const [, secondOpts] = mockFetch.mock.calls[1];
+      expect(secondOpts.headers.Authorization).toBe('Bearer fresh_token');
+      expect(result).toEqual(webBotAuthBlock);
+    });
+
+    it('throws LinkApiError on HTTP error', async () => {
+      mockFetchResponse(422, { error: 'Invalid URL' });
+
+      await expect(resource.getHeaders(validUrl)).rejects.toThrow(
+        'Failed to get web bot auth headers (422)',
+      );
+    });
+
+    it('throws when response is missing web_bot_auth block', async () => {
+      mockFetchResponse(200, { identity_token: 'tok_test123' });
+
+      await expect(resource.getHeaders(validUrl)).rejects.toThrow(
+        'Credentials response missing web_bot_auth block',
+      );
+    });
+
+    it('throws when access token is unavailable', async () => {
+      getAccessToken.mockRejectedValueOnce(new Error('Missing access token'));
+
+      await expect(resource.getHeaders(validUrl)).rejects.toThrow(
+        'Missing access token',
+      );
+    });
+
+    it('throws on invalid URL', async () => {
+      await expect(resource.getHeaders('not-a-url')).rejects.toThrow(
+        'Invalid URL',
+      );
+    });
+  });
+});

--- a/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
+++ b/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
@@ -1,3 +1,4 @@
+import { LinkApiError, LinkSdkError } from '@/errors';
 import type { WebBotAuthBlock } from '@/types/index';
 import { WebBotAuthResource } from '@/resources/web-bot-auth';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -137,17 +138,17 @@ describe('WebBotAuthResource', () => {
     it('throws LinkApiError on HTTP error', async () => {
       mockFetchResponse(422, { error: 'Invalid URL' });
 
-      await expect(resource.getHeaders(validUrl)).rejects.toThrow(
-        'Failed to get web bot auth headers (422)',
-      );
+      const err = await resource.getHeaders(validUrl).catch((e) => e);
+      expect(err).toBeInstanceOf(LinkApiError);
+      expect(err.message).toMatch('Failed to get web bot auth headers (422)');
     });
 
-    it('throws when response is missing web_bot_auth block', async () => {
+    it('throws LinkSdkError when response is missing web_bot_auth block', async () => {
       mockFetchResponse(200, { identity_token: 'tok_test123' });
 
-      await expect(resource.getHeaders(validUrl)).rejects.toThrow(
-        'Credentials response missing web_bot_auth block',
-      );
+      const err = await resource.getHeaders(validUrl).catch((e) => e);
+      expect(err).toBeInstanceOf(LinkSdkError);
+      expect(err.message).toMatch('Credentials response missing web_bot_auth block');
     });
 
     it('throws when access token is unavailable', async () => {
@@ -158,10 +159,10 @@ describe('WebBotAuthResource', () => {
       );
     });
 
-    it('throws on invalid URL', async () => {
-      await expect(resource.getHeaders('not-a-url')).rejects.toThrow(
-        'Invalid URL',
-      );
+    it('throws LinkSdkError on invalid URL', async () => {
+      const err = await resource.getHeaders('not-a-url').catch((e) => e);
+      expect(err).toBeInstanceOf(LinkSdkError);
+      expect(err.message).toMatch('Invalid URL');
     });
   });
 });

--- a/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
+++ b/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
@@ -1,6 +1,6 @@
 import { LinkApiError, LinkSdkError } from '@/errors';
-import type { WebBotAuthBlock } from '@/types/index';
 import { WebBotAuthResource } from '@/resources/web-bot-auth';
+import type { WebBotAuthBlock } from '@/types/index';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockFetch = vi.fn();
@@ -148,7 +148,9 @@ describe('WebBotAuthResource', () => {
 
       const err = await resource.getHeaders(validUrl).catch((e) => e);
       expect(err).toBeInstanceOf(LinkSdkError);
-      expect(err.message).toMatch('Credentials response missing web_bot_auth block');
+      expect(err.message).toMatch(
+        'Credentials response missing web_bot_auth block',
+      );
     });
 
     it('throws when access token is unavailable', async () => {

--- a/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
+++ b/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
@@ -143,6 +143,17 @@ describe('WebBotAuthResource', () => {
       expect(err.message).toMatch('Failed to get web bot auth headers (422)');
     });
 
+    it('throws LinkSdkError when expires_at is malformed', async () => {
+      mockFetchResponse(200, {
+        ...credentialsResponse,
+        web_bot_auth: { ...webBotAuthBlock, expires_at: 'not-a-date' },
+      });
+
+      const err = await resource.getHeaders(validUrl).catch((e) => e);
+      expect(err).toBeInstanceOf(LinkSdkError);
+      expect(err.message).toMatch('invalid expires_at');
+    });
+
     it('throws LinkSdkError when response is missing web_bot_auth block', async () => {
       mockFetchResponse(200, { identity_token: 'tok_test123' });
 

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -9,6 +9,7 @@ import type {
   SpendRequest,
   Total,
   UserInfo,
+  WebBotAuthBlock,
 } from '@/types/index';
 
 export interface IAuthResource {
@@ -85,4 +86,8 @@ export interface IShippingAddressResource {
 
 export interface IUserInfoResource {
   retrieve(): Promise<UserInfo>;
+}
+
+export interface IWebBotAuthResource {
+  getHeaders(url: string): Promise<WebBotAuthBlock>;
 }

--- a/packages/sdk/src/resources/web-bot-auth.ts
+++ b/packages/sdk/src/resources/web-bot-auth.ts
@@ -3,7 +3,7 @@ import {
   requireFetchImplementation,
   resolveLinkSdkConfig,
 } from '@/config';
-import { LinkApiError, LinkTransportError } from '@/errors';
+import { LinkApiError, LinkSdkError, LinkTransportError } from '@/errors';
 import type {
   AccessTokenProvider,
   IWebBotAuthResource,
@@ -24,6 +24,9 @@ interface CacheEntry {
 
 const EXPIRY_BUFFER_MS = 30_000;
 
+// TODO: rawFetch/apiFetch is duplicated across all SDK resources. Extract into
+// a shared ApiClient utility before adding more resources. Each copy has already
+// diverged slightly (e.g. body support), making bugs harder to fix consistently.
 export class WebBotAuthResource implements IWebBotAuthResource {
   private readonly verbose: boolean;
   private readonly getAccessToken: AccessTokenProvider;
@@ -111,12 +114,29 @@ export class WebBotAuthResource implements IWebBotAuthResource {
     return res;
   }
 
+  /**
+   * Returns Web Bot Auth signature headers for the given URL's authority.
+   *
+   * Pass the full merchant URL (e.g. `https://merchant.com/checkout`). The
+   * authority (hostname) is extracted and used as the cache key — repeated
+   * calls for the same domain within the 10-minute signature window are served
+   * from cache without a network round-trip.
+   *
+   * Attach the returned `signature` and `signature_input` values as the
+   * `Signature` and `Signature-Input` HTTP headers on outbound requests to
+   * the merchant site.
+   *
+   * @throws {LinkSdkError} if `url` is not a valid URL
+   * @throws {LinkSdkError} if the credentials response is missing the web_bot_auth block
+   * @throws {LinkApiError} if the credentials endpoint returns a non-2xx status
+   * @throws {LinkTransportError} if the network request fails
+   */
   async getHeaders(url: string): Promise<WebBotAuthBlock> {
     let authority: string;
     try {
       authority = new URL(url).hostname;
     } catch {
-      throw new Error(`Invalid URL: ${url}`);
+      throw new LinkSdkError(`Invalid URL: ${url}`);
     }
 
     const cached = this.cache.get(authority);
@@ -146,11 +166,9 @@ export class WebBotAuthResource implements IWebBotAuthResource {
     const body = data as Record<string, unknown> | null;
     const webBotAuth = body?.web_bot_auth as WebBotAuthBlock | undefined;
     if (!webBotAuth) {
-      throw new LinkApiError('Credentials response missing web_bot_auth block', {
-        status,
-        rawBody,
-        details: data,
-      });
+      throw new LinkSdkError(
+        `Credentials response missing web_bot_auth block (status ${status})`,
+      );
     }
 
     this.cache.set(authority, {

--- a/packages/sdk/src/resources/web-bot-auth.ts
+++ b/packages/sdk/src/resources/web-bot-auth.ts
@@ -39,6 +39,8 @@ export class WebBotAuthResource implements IWebBotAuthResource {
     const config = resolveLinkSdkConfig(options);
     this.verbose = config.verbose;
     this.getAccessToken = config.getAccessToken;
+    // defaultHeaders (if any) are baked into config.fetch by resolveLinkSdkConfig
+    // via createDefaultHeadersFetch — no separate field needed.
     this.fetchImpl = requireFetchImplementation(config);
     this.credentialsEndpoint = `${config.apiBaseUrl}/v1/agent_identity/credentials`;
     this.logger = config.logger;
@@ -171,10 +173,14 @@ export class WebBotAuthResource implements IWebBotAuthResource {
       );
     }
 
-    this.cache.set(authority, {
-      block: webBotAuth,
-      expiresAt: Date.parse(webBotAuth.expires_at),
-    });
+    const expiresAt = Date.parse(webBotAuth.expires_at);
+    if (Number.isNaN(expiresAt)) {
+      throw new LinkSdkError(
+        `Credentials response has invalid expires_at: ${webBotAuth.expires_at}`,
+      );
+    }
+
+    this.cache.set(authority, { block: webBotAuth, expiresAt });
 
     return webBotAuth;
   }

--- a/packages/sdk/src/resources/web-bot-auth.ts
+++ b/packages/sdk/src/resources/web-bot-auth.ts
@@ -1,0 +1,163 @@
+import {
+  type LinkOptions,
+  requireFetchImplementation,
+  resolveLinkSdkConfig,
+} from '@/config';
+import { LinkApiError, LinkTransportError } from '@/errors';
+import type {
+  AccessTokenProvider,
+  IWebBotAuthResource,
+} from '@/resources/interfaces';
+import type { WebBotAuthBlock } from '@/types/index';
+
+interface ApiFetchOptions {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+interface CacheEntry {
+  block: WebBotAuthBlock;
+  expiresAt: number;
+}
+
+const EXPIRY_BUFFER_MS = 30_000;
+
+export class WebBotAuthResource implements IWebBotAuthResource {
+  private readonly verbose: boolean;
+  private readonly getAccessToken: AccessTokenProvider;
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly credentialsEndpoint: string;
+  private readonly logger: { debug(message: string): void };
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(options: LinkOptions) {
+    const config = resolveLinkSdkConfig(options);
+    this.verbose = config.verbose;
+    this.getAccessToken = config.getAccessToken;
+    this.fetchImpl = requireFetchImplementation(config);
+    this.credentialsEndpoint = `${config.apiBaseUrl}/v1/agent_identity/credentials`;
+    this.logger = config.logger;
+  }
+
+  private async rawFetch(
+    opts: ApiFetchOptions,
+  ): Promise<{ status: number; data: unknown; rawBody: string }> {
+    if (this.verbose) {
+      const redactedHeaders = { ...opts.headers };
+      if (redactedHeaders.Authorization)
+        redactedHeaders.Authorization = 'Bearer <redacted>';
+      this.logger.debug(`> ${opts.method} ${opts.url}`);
+      this.logger.debug(`  Headers: ${JSON.stringify(redactedHeaders)}`);
+      if (opts.body) this.logger.debug(opts.body);
+    }
+
+    const fetchOpts: RequestInit = {
+      method: opts.method,
+      headers: opts.headers,
+    };
+
+    if (opts.body) {
+      fetchOpts.body = opts.body;
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(opts.url, fetchOpts);
+    } catch (error) {
+      throw new LinkTransportError(
+        `Request failed: ${opts.method} ${opts.url}`,
+        { cause: error },
+      );
+    }
+    const rawBody = await response.text();
+
+    let data: unknown = null;
+    try {
+      data = JSON.parse(rawBody);
+    } catch {
+      // non-JSON response
+    }
+
+    if (this.verbose) {
+      this.logger.debug(`< ${response.status} ${response.statusText}`);
+      response.headers.forEach((value, key) => {
+        this.logger.debug(`  ${key}: ${value}`);
+      });
+      this.logger.debug(JSON.stringify(data, null, 2) ?? rawBody);
+    }
+
+    return { status: response.status, data, rawBody };
+  }
+
+  private async apiFetch(
+    opts: ApiFetchOptions,
+  ): Promise<{ status: number; data: unknown; rawBody: string }> {
+    const token = await this.getAccessToken();
+    const authedOpts = {
+      ...opts,
+      headers: { ...opts.headers, Authorization: `Bearer ${token}` },
+    };
+
+    const res = await this.rawFetch(authedOpts);
+
+    if (res.status === 401) {
+      const refreshedToken = await this.getAccessToken({ forceRefresh: true });
+      authedOpts.headers.Authorization = `Bearer ${refreshedToken}`;
+      return this.rawFetch(authedOpts);
+    }
+
+    return res;
+  }
+
+  async getHeaders(url: string): Promise<WebBotAuthBlock> {
+    let authority: string;
+    try {
+      authority = new URL(url).hostname;
+    } catch {
+      throw new Error(`Invalid URL: ${url}`);
+    }
+
+    const cached = this.cache.get(authority);
+    if (cached && Date.now() < cached.expiresAt - EXPIRY_BUFFER_MS) {
+      return cached.block;
+    }
+
+    const { status, data, rawBody } = await this.apiFetch({
+      method: 'POST',
+      url: this.credentialsEndpoint,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url }),
+    });
+
+    if (status < 200 || status >= 300) {
+      const body = data as Record<string, unknown> | null;
+      const msg =
+        (body?.error as string | undefined) ??
+        (body?.message as string | undefined) ??
+        (rawBody || 'unknown error');
+      throw new LinkApiError(
+        `Failed to get web bot auth headers (${status}): ${msg}`,
+        { status, rawBody, details: data },
+      );
+    }
+
+    const body = data as Record<string, unknown> | null;
+    const webBotAuth = body?.web_bot_auth as WebBotAuthBlock | undefined;
+    if (!webBotAuth) {
+      throw new LinkApiError('Credentials response missing web_bot_auth block', {
+        status,
+        rawBody,
+        details: data,
+      });
+    }
+
+    this.cache.set(authority, {
+      block: webBotAuth,
+      expiresAt: Date.parse(webBotAuth.expires_at),
+    });
+
+    return webBotAuth;
+  }
+}

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -146,3 +146,11 @@ export interface ShippingAddressRecord {
   nickname: string | null;
   address: ShippingAddress | null;
 }
+
+export interface WebBotAuthBlock {
+  signature: string;
+  signature_input: string;
+  signature_agent: string;
+  authority: string;
+  expires_at: string;
+}


### PR DESCRIPTION
r? @kreese-stripe @danhill-stripe @bendavis-stripe 

### Summary and motivation

Adds `WebBotAuthResource` to `@stripe/link-sdk` the SDK component that fetches pre-signed [Web Bot Auth](https://developers.cloudflare.com/bots/reference/bot-verification/web-bot-auth/) headers from the Link backend so AI agents can prove their identity to merchant sites protected by Cloudflare bot filtering.

**What this adds:**

- New `WebBotAuthBlock` type in mirroring the backend response shape:
  `{ signature, signature_input, signature_agent, authority, expires_at }`.
- New `IWebBotAuthResource` interface with a single method: `getHeaders(url: string): Promise<WebBotAuthBlock>`.
- `WebBotAuthResource` class implementing the interface. On `getHeaders(url)`:
  1. Extracts the authority (hostname) from the URL.
  2. Checks an in-memory per-authority cache; returns the cached block if it expires
     more than 30 seconds in the future.
  3. Otherwise POSTs to `POST /v1/agent_identity/credentials` (authenticated with the
     user's Link OAuth bearer token) with `{ url }` as the JSON body.
  4. Extracts the `web_bot_auth` block from the response, caches it keyed by hostname,
     and returns it.
  5. On 401, refreshes the access token once and retries (same pattern as all other SDK resources).
- `WebBotAuthResource` wired into `ResourceFactory` in the CLI package with lazy caching,
  same as `SpendRequestResource`, `PaymentMethodsResource`, etc.


**Why:**

AI agents using Link CLI to complete checkout on merchant sites get blocked by Cloudflare and Vercel's automated bot detection: their traffic is indistinguishable from scraper traffic.
Web Bot Auth is an IETF-draft protocol where registered bots attach a cryptographic signature to every request, allowing CDN/WAF managed rulesets to bypass bot challenges without user interaction.

**Signatures are valid for 10 minutes.** The per-authority cache avoids a round-trip to `api.link.com` on every request to the same merchant domain within that window.


### Test plan

- [x] `packages/sdk/src/resources/__tests__/web-bot-auth.test.ts` (11 new unit tests).

- [x] `packages/cli/src/utils/__tests__/resource-factory.test.ts` updated:
  - `createWebBotAuthResource()` returns cached instance on repeated calls
  - Returns `instanceof WebBotAuthResource`