### PR TITLE
Add `web-bot-auth sign <url>` command

### DIFF
--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -8,6 +8,7 @@ import { createPaymentMethodsCli } from './commands/payment-methods';
 import { createShippingAddressCli } from './commands/shipping-address';
 import { createSpendRequestCli } from './commands/spend-request';
 import { createUserInfoCli } from './commands/user-info';
+import { createWebBotAuthCli } from './commands/web-bot-auth';
 import { ResourceFactory } from './utils/resource-factory';
 import {
   createAgentUpdateInfoProvider,
@@ -82,6 +83,9 @@ cli.command(
   createUserInfoCli(() => factory.createUserInfoResource(), authStorage),
 );
 cli.command(createMppCli(spendRequestRepo, authStorage));
+cli.command(
+  createWebBotAuthCli(() => factory.createWebBotAuthResource(), authStorage),
+);
 cli.command(
   createDemoCli(
     authRepo,

--- a/packages/cli/src/commands/web-bot-auth/__tests__/web-bot-auth.test.tsx
+++ b/packages/cli/src/commands/web-bot-auth/__tests__/web-bot-auth.test.tsx
@@ -46,6 +46,22 @@ describe('web-bot-auth', () => {
   });
 
   describe('WebBotAuthSign', () => {
+    it('renders loading spinner initially', () => {
+      const resource = {
+        getHeaders: vi.fn(() => new Promise(() => {})),
+      } as unknown as IWebBotAuthResource;
+
+      const { lastFrame } = render(
+        <WebBotAuthSign
+          resource={resource}
+          url="https://wine-merchant.com/checkout"
+          onComplete={() => {}}
+        />,
+      );
+
+      expect(lastFrame()).toContain('Getting Web Bot Auth headers');
+    });
+
     it('renders signature fields on success', async () => {
       const resource = {
         getHeaders: vi.fn(async () => webBotAuthBlock),
@@ -62,9 +78,32 @@ describe('web-bot-auth', () => {
       await vi.waitFor(() => {
         const frame = lastFrame();
         expect(frame).toContain('sig1=:stub_sig:');
+        expect(frame).toContain('sig1=("@authority"');
         expect(frame).toContain('wine-merchant.com');
         expect(frame).toContain('2099-12-31');
       });
+    });
+
+    it('calls onComplete with the result block', async () => {
+      const resource = {
+        getHeaders: vi.fn(async () => webBotAuthBlock),
+      } as unknown as IWebBotAuthResource;
+      const onComplete = vi.fn();
+
+      render(
+        <WebBotAuthSign
+          resource={resource}
+          url="https://wine-merchant.com/checkout"
+          onComplete={onComplete}
+        />,
+      );
+
+      await vi.waitFor(
+        () => {
+          expect(onComplete).toHaveBeenCalledWith(webBotAuthBlock);
+        },
+        { timeout: 3000 },
+      );
     });
 
     it('renders error message on failure', async () => {

--- a/packages/cli/src/commands/web-bot-auth/__tests__/web-bot-auth.test.tsx
+++ b/packages/cli/src/commands/web-bot-auth/__tests__/web-bot-auth.test.tsx
@@ -1,0 +1,90 @@
+import type { IWebBotAuthResource, WebBotAuthBlock } from '@stripe/link-sdk';
+import { render } from 'ink-testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import { sanitizeResource } from '../../../utils/resource-factory';
+import { WebBotAuthSign } from '../sign';
+
+const ESCAPE_PAYLOAD = '\x1b[2JEvil\rHidden';
+const CLEAN_TEXT = 'EvilHidden';
+
+const webBotAuthBlock: WebBotAuthBlock = {
+  signature: 'sig1=:stub_sig:',
+  signature_input:
+    'sig1=("@authority" "signature-agent");created=1715400000;keyid="stub_keyid";alg="ed25519";expires=1715400600;tag="web-bot-auth"',
+  signature_agent:
+    'https://api.link.com/.well-known/http-message-signatures-directory',
+  authority: 'wine-merchant.com',
+  expires_at: '2099-12-31T23:59:59Z',
+};
+
+describe('web-bot-auth', () => {
+  describe('sanitization', () => {
+    it('sanitizes escape sequences in signature fields', async () => {
+      const resource = sanitizeResource({
+        getHeaders: vi.fn(async () => ({
+          ...webBotAuthBlock,
+          signature: `sig1=:${ESCAPE_PAYLOAD}:`,
+          authority: ESCAPE_PAYLOAD,
+        })),
+      } as unknown as IWebBotAuthResource);
+
+      const { lastFrame } = render(
+        <WebBotAuthSign
+          resource={resource}
+          url="https://wine-merchant.com/checkout"
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain(CLEAN_TEXT);
+        expect(frame).not.toContain('\x1b[2J');
+        expect(frame).not.toContain('\r');
+      });
+    });
+  });
+
+  describe('WebBotAuthSign', () => {
+    it('renders signature fields on success', async () => {
+      const resource = {
+        getHeaders: vi.fn(async () => webBotAuthBlock),
+      } as unknown as IWebBotAuthResource;
+
+      const { lastFrame } = render(
+        <WebBotAuthSign
+          resource={resource}
+          url="https://wine-merchant.com/checkout"
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('sig1=:stub_sig:');
+        expect(frame).toContain('wine-merchant.com');
+        expect(frame).toContain('2099-12-31');
+      });
+    });
+
+    it('renders error message on failure', async () => {
+      const resource = {
+        getHeaders: vi.fn(async () => {
+          throw new Error('Not authenticated');
+        }),
+      } as unknown as IWebBotAuthResource;
+
+      const { lastFrame } = render(
+        <WebBotAuthSign
+          resource={resource}
+          url="https://wine-merchant.com/checkout"
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        expect(lastFrame()).toContain('Not authenticated');
+      });
+    });
+  });
+});

--- a/packages/cli/src/commands/web-bot-auth/index.tsx
+++ b/packages/cli/src/commands/web-bot-auth/index.tsx
@@ -1,0 +1,48 @@
+import type { AuthStorage, IWebBotAuthResource } from '@stripe/link-sdk';
+import { Cli, z } from 'incur';
+import React from 'react';
+import { renderInteractive } from '../../utils/render-interactive';
+import { requireAuth } from '../../utils/require-auth';
+import { WebBotAuthSign } from './sign';
+
+export function createWebBotAuthCli(
+  createResource: () => IWebBotAuthResource,
+  authStorage?: AuthStorage,
+) {
+  const cli = Cli.create('web-bot-auth', {
+    description: 'Web Bot Auth commands for Cloudflare/Vercel bot verification',
+  });
+
+  cli.command('sign', {
+    description:
+      'Get Web Bot Auth signature headers for a URL. ' +
+      'Attach the returned Signature and Signature-Input headers to ' +
+      'outbound requests to the merchant site to bypass bot protection.',
+    args: z.object({
+      url: z
+        .string()
+        .describe('Merchant URL to sign (e.g. https://merchant.com/checkout)'),
+    }),
+    outputPolicy: 'agent-only' as const,
+    middleware: [requireAuth(authStorage)],
+    async run(c) {
+      const resource = createResource();
+      const { url } = c.args;
+
+      if (!c.agent && !c.formatExplicit) {
+        return renderInteractive(
+          <WebBotAuthSign
+            resource={resource}
+            url={url}
+            onComplete={() => {}}
+          />,
+          () => resource.getHeaders(url),
+        );
+      }
+
+      return resource.getHeaders(url);
+    },
+  });
+
+  return cli;
+}

--- a/packages/cli/src/commands/web-bot-auth/index.tsx
+++ b/packages/cli/src/commands/web-bot-auth/index.tsx
@@ -1,4 +1,8 @@
-import type { AuthStorage, IWebBotAuthResource } from '@stripe/link-sdk';
+import type {
+  AuthStorage,
+  IWebBotAuthResource,
+  WebBotAuthBlock,
+} from '@stripe/link-sdk';
 import { Cli, z } from 'incur';
 import React from 'react';
 import { renderInteractive } from '../../utils/render-interactive';
@@ -30,13 +34,20 @@ export function createWebBotAuthCli(
       const { url } = c.args;
 
       if (!c.agent && !c.formatExplicit) {
+        let capturedBlock: WebBotAuthBlock | null = null;
         return renderInteractive(
           <WebBotAuthSign
             resource={resource}
             url={url}
-            onComplete={() => {}}
+            onComplete={(result) => {
+              capturedBlock = result;
+            }}
           />,
-          () => resource.getHeaders(url),
+          () => {
+            if (!capturedBlock)
+              throw new Error('Component exited without producing a result');
+            return capturedBlock;
+          },
         );
       }
 

--- a/packages/cli/src/commands/web-bot-auth/sign.tsx
+++ b/packages/cli/src/commands/web-bot-auth/sign.tsx
@@ -1,5 +1,5 @@
 import type { IWebBotAuthResource, WebBotAuthBlock } from '@stripe/link-sdk';
-import { Box, Text } from 'ink';
+import { Box, Text, useApp } from 'ink';
 import Spinner from 'ink-spinner';
 import type React from 'react';
 import { useCallback } from 'react';
@@ -16,8 +16,16 @@ export const WebBotAuthSign: React.FC<WebBotAuthSignProps> = ({
   url,
   onComplete,
 }) => {
+  const { exit } = useApp();
   const action = useCallback(() => resource.getHeaders(url), [resource, url]);
-  const { status, data: block, error } = useAsyncAction(action, onComplete);
+  const handleComplete = useCallback(
+    (result: WebBotAuthBlock | null) => {
+      onComplete(result);
+      exit();
+    },
+    [onComplete, exit],
+  );
+  const { status, data: block, error } = useAsyncAction(action, handleComplete);
 
   if (status === 'loading') {
     return (
@@ -38,25 +46,27 @@ export const WebBotAuthSign: React.FC<WebBotAuthSignProps> = ({
     );
   }
 
+  if (!block) return null;
+
   return (
     <Box flexDirection="column">
       <Text color="green">✓ Web Bot Auth headers obtained</Text>
       <Box flexDirection="column" marginTop={1} paddingX={2}>
         <Text>
           <Text dimColor>Signature: </Text>
-          {block?.signature}
+          {block.signature}
         </Text>
         <Text>
           <Text dimColor>Signature-Input: </Text>
-          {block?.signature_input}
+          {block.signature_input}
         </Text>
         <Text>
           <Text dimColor>Authority: </Text>
-          {block?.authority}
+          {block.authority}
         </Text>
         <Text>
           <Text dimColor>Expires: </Text>
-          {block?.expires_at}
+          {block.expires_at}
         </Text>
       </Box>
     </Box>

--- a/packages/cli/src/commands/web-bot-auth/sign.tsx
+++ b/packages/cli/src/commands/web-bot-auth/sign.tsx
@@ -1,0 +1,64 @@
+import type { IWebBotAuthResource, WebBotAuthBlock } from '@stripe/link-sdk';
+import { Box, Text } from 'ink';
+import Spinner from 'ink-spinner';
+import type React from 'react';
+import { useCallback } from 'react';
+import { useAsyncAction } from '../../hooks/use-async-action';
+
+interface WebBotAuthSignProps {
+  resource: IWebBotAuthResource;
+  url: string;
+  onComplete: (result: WebBotAuthBlock | null) => void;
+}
+
+export const WebBotAuthSign: React.FC<WebBotAuthSignProps> = ({
+  resource,
+  url,
+  onComplete,
+}) => {
+  const action = useCallback(() => resource.getHeaders(url), [resource, url]);
+  const { status, data: block, error } = useAsyncAction(action, onComplete);
+
+  if (status === 'loading') {
+    return (
+      <Box>
+        <Text color="cyan">
+          <Spinner type="dots" /> Getting Web Bot Auth headers...
+        </Text>
+      </Box>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <Box flexDirection="column">
+        <Text color="red">✗ Failed to get Web Bot Auth headers</Text>
+        <Text color="red">{error}</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text color="green">✓ Web Bot Auth headers obtained</Text>
+      <Box flexDirection="column" marginTop={1} paddingX={2}>
+        <Text>
+          <Text dimColor>Signature: </Text>
+          {block?.signature}
+        </Text>
+        <Text>
+          <Text dimColor>Signature-Input: </Text>
+          {block?.signature_input}
+        </Text>
+        <Text>
+          <Text dimColor>Authority: </Text>
+          {block?.authority}
+        </Text>
+        <Text>
+          <Text dimColor>Expires: </Text>
+          {block?.expires_at}
+        </Text>
+      </Box>
+    </Box>
+  );
+};


### PR DESCRIPTION
## Summary

Adds the `link-cli web-bot-auth sign <url>` command, which fetches Web Bot Auth signature headers for a given merchant URL and returns them for injection into outbound HTTP requests.

**New command:**
```
link-cli web-bot-auth sign <url>
```

**What it returns** (`WebBotAuthBlock`):
```json
{
  "signature": "sig1=:...",
  "signature_input": "sig1=(\"@authority\" \"signature-agent\");created=...;keyid=...;alg=\"ed25519\";expires=...;tag=\"web-bot-auth\"",
  "signature_agent": "https://api.link.com/.well-known/http-message-signatures-directory",
  "authority": "merchant.com",
  "expires_at": "2026-05-19T00:10:00Z"
}
```

**Interactive mode** (human-facing): renders a spinner while fetching, then displays a success view with all fields labeled.

**Agent / format mode** (`--format json`, `--mcp`): returns the raw `WebBotAuthBlock` JSON, no interactive UI.

### Implementation notes

- **Capture pattern** (not double-call): `onComplete` captures the result into a local variable; `getResult` returns it. Matches the pattern in `mpp pay`. The previous `user-info retrieve` pattern (pass `onComplete={() => {}}` then call the resource a second time in `getResult`) is avoided here because it makes two round-trips to the API.

- **Explicit `exit()`**: `WebBotAuthSign` calls `useApp().exit()` inside the `onComplete` callback so Ink terminates deterministically instead of relying on event loop drain. This pairs with the capture pattern; the `getResult` lambda is only called after `waitUntilExit()` resolves.

- **Depends on CLI-1** (`nvp/link-cli-web-bot-auth`), which added `WebBotAuthResource` and `IWebBotAuthResource` to `@stripe/link-sdk`. That PR has been merged; this branch is based on its merge commit.

## Motivation

AI agents making purchases on behalf of users send HTTP requests to merchant sites. Many merchants run Cloudflare or Vercel in front of their checkout flows, and those platforms flag non-browser traffic as bots and return 403 responses before the agent can complete the transaction.

Web Bot Auth (an extension of RFC 9421 HTTP Message Signatures) solves this: an authenticated Link user can prove that their agent is authorized. The Link backend signs requests with an Ed25519 key tied to the user's identity. The merchant site verifies the signature against a published JWKS directory (`/.well-known/http-message-signatures-directory`).

This command is the agent-facing surface for that flow:

1. Agent calls `link-cli web-bot-auth sign <merchant-url>`.
2. CLI fetches pre-signed headers
3. Agent attaches `Signature` and `Signature-Input` headers to the outgoing HTTP request to the merchant.
4. Cloudflare/Vercel verifies the signature and allows the request through.

Without this command, agents must either implement the signing protocol themselves (requiring direct API access and key management) or fall back to browser automation (slower, brittle, higher compute cost).

## Testing

### Unit tests 
- `packages/cli/src/commands/web-bot-auth/__tests__/web-bot-auth.test.tsx`

