### PR TITLE
Update SKILL.md with Web Bot Auth browsing instructions

### DIFF
--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -122,6 +122,16 @@ What you find determines which credential type to use:
 | HTTP 402 with `method="stripe"` in `www-authenticate` | `shared_payment_token` | Shared payment token (SPT) |
 | HTTP 402 without `method="stripe"` in `www-authenticate` | not supported | Do not continue |
 
+**If the merchant site returns 403 (bot protection):**
+
+Some merchants use Cloudflare or Vercel bot protection that blocks automated requests. If you receive a 403 when browsing the merchant site, use `web-bot-auth sign` to obtain signed headers:
+
+```bash
+link-cli web-bot-auth sign <merchant-url>
+```
+
+Attach the returned `Signature` and `Signature-Input` headers to your HTTP requests to the merchant. The headers are valid for ~10 minutes and are scoped to the merchant's domain.
+
 **For 402 responses:** The `www-authenticate` header may contain **multiple** payment challenges (e.g. `tempo`, `stripe`) in a single header value. Do not try to decode the payload manually. Pass the **full raw `WWW-Authenticate` header value** to Link CLI and let `mpp decode` select and validate the `method="stripe"` challenge.
 
 To derive `network_id`, use Link CLI's challenge decoder:
@@ -190,7 +200,7 @@ link-cli spend-request retrieve <id> --include card --output-file /tmp/link-card
 link-cli mpp pay <url> --spend-request-id <id> [--method POST] [--data '{"amount":100}'] [--header 'Name: Value']
 ```
 
-`mpp pay` handles the full 402 flow automatically: probes the URL, parses the `www-authenticate` header, builds the `Authorization: Payment` credential using the SPT, and retries.
+`mpp pay` handles the full flow automatically: if the merchant returns **403** (bot protection), it fetches Web Bot Auth headers and retries transparently; if it then returns **402**, it parses the `www-authenticate` header, builds the `Authorization: Payment` credential using the SPT, and retries. No manual `web-bot-auth sign` call is needed when using `mpp pay`.
 
 
 ## Important
@@ -213,6 +223,8 @@ All errors are output as JSON with `code` and `message` fields, with exit code 1
 | API rejects `merchant_name` or `merchant_url` | These fields are forbidden when `credential_type` is `shared_payment_token` | Remove both fields from the request; SPT flows identify the merchant via `network_id` instead |
 | Spend request approved but payment fails immediately | Wrong credential type for the merchant (e.g. `card` on a 402-only endpoint) | Go back to Step 2, re-evaluate the merchant, create a new spend request with the correct `credential_type` |
 | Auth token expired mid-session (exit code 1 during approval polling) | Token refresh failure during background polling | Re-authenticate with `auth login`, then retrieve the existing spend request or resume polling. Only create a new spend request if the original one expired, was denied, was canceled, or its shared payment token was already consumed |
+| 403 when browsing merchant site in Step 2 | Bot protection (Cloudflare/Vercel) blocking automated requests | Run `link-cli web-bot-auth sign <url>` and attach the returned `Signature` and `Signature-Input` headers to your browsing requests |
+| `Received 403 before and after Web Bot Auth retry` from `mpp pay` | Merchant returns 403 for a reason unrelated to bot protection (auth, geo-block, etc.) | Cannot proceed with this URL — report to the user that the merchant is blocking access |
 
 ## Further docs
 

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -200,7 +200,7 @@ link-cli spend-request retrieve <id> --include card --output-file /tmp/link-card
 link-cli mpp pay <url> --spend-request-id <id> [--method POST] [--data '{"amount":100}'] [--header 'Name: Value']
 ```
 
-`mpp pay` handles the full flow automatically: if the merchant returns **403** (bot protection), it fetches Web Bot Auth headers and retries transparently; if it then returns **402**, it parses the `www-authenticate` header, builds the `Authorization: Payment` credential using the SPT, and retries. No manual `web-bot-auth sign` call is needed when using `mpp pay`.
+`mpp pay` handles the full 402 flow automatically: probes the URL, parses the `www-authenticate` header, builds the `Authorization: Payment` credential using the SPT, and retries.
 
 
 ## Important
@@ -224,7 +224,6 @@ All errors are output as JSON with `code` and `message` fields, with exit code 1
 | Spend request approved but payment fails immediately | Wrong credential type for the merchant (e.g. `card` on a 402-only endpoint) | Go back to Step 2, re-evaluate the merchant, create a new spend request with the correct `credential_type` |
 | Auth token expired mid-session (exit code 1 during approval polling) | Token refresh failure during background polling | Re-authenticate with `auth login`, then retrieve the existing spend request or resume polling. Only create a new spend request if the original one expired, was denied, was canceled, or its shared payment token was already consumed |
 | 403 when browsing merchant site in Step 2 | Bot protection (Cloudflare/Vercel) blocking automated requests | Run `link-cli web-bot-auth sign <url>` and attach the returned `Signature` and `Signature-Input` headers to your browsing requests |
-| `Received 403 before and after Web Bot Auth retry` from `mpp pay` | Merchant returns 403 for a reason unrelated to bot protection (auth, geo-block, etc.) | Cannot proceed with this URL — report to the user that the merchant is blocking access |
 
 ## Further docs
 


### PR DESCRIPTION
## Summary

Updates `skills/create-payment-credential/SKILL.md` so agents know about Web Bot Auth and use it correctly. Three targeted additions to the existing skill file:

1. **Step 2: bot protection during browsing**: new subsection after the credential-type table explaining what to do when the merchant site returns 403. Agents are told to call `web-bot-auth sign <url>` and attach the returned `Signature` and `Signature-Input` headers to their HTTP requests.

2. **Step 5: `mpp pay` auto-bypass**: updated description of `mpp pay` to tell agents that 403 (bot protection) is handled automatically before the 402 flow  no manual `web-bot-auth sign` call is needed when using `mpp pay`.

3. **Errors table: two new rows**: recovery guidance for (a) 403 during merchant browsing in Step 2, and (b) the `Received 403 before and after Web Bot Auth retry` error from `mpp pay`, which signals the merchant is blocking for a non-bot-protection reason.

## Motivation

Without this update, the SKILL.md that agents load has no mention of bot protection. An agent following the current skill would:

- Hit a Cloudflare-protected merchant in Step 2, get a 403, and have no recovery path; likely abandoning the purchase or prompting the user unnecessarily.
- Not know that `mpp pay` handles 403 transparently, potentially trying to manually sign and inject headers before calling `mpp pay` (redundant work).
- Receive the `Received 403 before and after Web Bot Auth retry` error from `mpp pay` with no understanding of what it means or what to do next.

The SKILL.md is the canonical source of truth that LLMs use to reason about Link. Code without a skill update ships dead capability: agents won't use what they can't discover.