### PR TITLE
feat(sdk): migrate WebBotAuthResource to POST /web_bot_auth/sign

### DIFF
--- a/packages/cli/src/commands/web-bot-auth/__tests__/web-bot-auth.test.tsx
+++ b/packages/cli/src/commands/web-bot-auth/__tests__/web-bot-auth.test.tsx
@@ -21,7 +21,7 @@ describe('web-bot-auth', () => {
   describe('sanitization', () => {
     it('sanitizes escape sequences in signature fields', async () => {
       const resource = sanitizeResource({
-        getHeaders: vi.fn(async () => ({
+        signUrl: vi.fn(async () => ({
           ...webBotAuthBlock,
           signature: `sig1=:${ESCAPE_PAYLOAD}:`,
           authority: ESCAPE_PAYLOAD,
@@ -48,7 +48,7 @@ describe('web-bot-auth', () => {
   describe('WebBotAuthSign', () => {
     it('renders loading spinner initially', () => {
       const resource = {
-        getHeaders: vi.fn(() => new Promise(() => {})),
+        signUrl: vi.fn(() => new Promise(() => {})),
       } as unknown as IWebBotAuthResource;
 
       const { lastFrame } = render(
@@ -64,7 +64,7 @@ describe('web-bot-auth', () => {
 
     it('renders signature fields on success', async () => {
       const resource = {
-        getHeaders: vi.fn(async () => webBotAuthBlock),
+        signUrl: vi.fn(async () => webBotAuthBlock),
       } as unknown as IWebBotAuthResource;
 
       const { lastFrame } = render(
@@ -86,7 +86,7 @@ describe('web-bot-auth', () => {
 
     it('calls onComplete with the result block', async () => {
       const resource = {
-        getHeaders: vi.fn(async () => webBotAuthBlock),
+        signUrl: vi.fn(async () => webBotAuthBlock),
       } as unknown as IWebBotAuthResource;
       const onComplete = vi.fn();
 
@@ -108,7 +108,7 @@ describe('web-bot-auth', () => {
 
     it('renders error message on failure', async () => {
       const resource = {
-        getHeaders: vi.fn(async () => {
+        signUrl: vi.fn(async () => {
           throw new Error('Not authenticated');
         }),
       } as unknown as IWebBotAuthResource;

--- a/packages/cli/src/commands/web-bot-auth/index.tsx
+++ b/packages/cli/src/commands/web-bot-auth/index.tsx
@@ -51,7 +51,7 @@ export function createWebBotAuthCli(
         );
       }
 
-      return resource.getHeaders(url);
+      return resource.signUrl(url);
     },
   });
 

--- a/packages/cli/src/commands/web-bot-auth/sign.tsx
+++ b/packages/cli/src/commands/web-bot-auth/sign.tsx
@@ -17,7 +17,7 @@ export const WebBotAuthSign: React.FC<WebBotAuthSignProps> = ({
   onComplete,
 }) => {
   const { exit } = useApp();
-  const action = useCallback(() => resource.getHeaders(url), [resource, url]);
+  const action = useCallback(() => resource.signUrl(url), [resource, url]);
   const handleComplete = useCallback(
     (result: WebBotAuthBlock | null) => {
       onComplete(result);

--- a/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
+++ b/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
@@ -26,7 +26,6 @@ const webBotAuthBlock: WebBotAuthBlock = {
 };
 
 const credentialsResponse = {
-  identity_token: 'tok_test123',
   web_bot_auth: webBotAuthBlock,
 };
 
@@ -45,14 +44,14 @@ describe('WebBotAuthResource', () => {
   });
 
   describe('getHeaders', () => {
-    it('sends POST to credentials endpoint with JSON body and Bearer auth', async () => {
+    it('sends POST to /web_bot_auth/sign with JSON body and Bearer auth', async () => {
       mockFetchResponse(200, credentialsResponse);
 
       await resource.getHeaders(validUrl);
 
       expect(mockFetch).toHaveBeenCalledOnce();
       const [url, opts] = mockFetch.mock.calls[0];
-      expect(url).toBe('https://api.link.com/v1/agent_identity/credentials');
+      expect(url).toBe('https://api.link.com/web_bot_auth/sign');
       expect(opts.method).toBe('POST');
       expect(opts.headers['Content-Type']).toBe('application/json');
       expect(opts.headers.Authorization).toBe('Bearer test_token');
@@ -160,7 +159,7 @@ describe('WebBotAuthResource', () => {
       const err = await resource.getHeaders(validUrl).catch((e) => e);
       expect(err).toBeInstanceOf(LinkSdkError);
       expect(err.message).toMatch(
-        'Credentials response missing web_bot_auth block',
+        'Sign response missing web_bot_auth block',
       );
     });
 

--- a/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
+++ b/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
@@ -43,11 +43,11 @@ describe('WebBotAuthResource', () => {
     vi.unstubAllGlobals();
   });
 
-  describe('getHeaders', () => {
+  describe('signUrl', () => {
     it('sends POST to /web_bot_auth/sign with JSON body and Bearer auth', async () => {
       mockFetchResponse(200, credentialsResponse);
 
-      await resource.getHeaders(validUrl);
+      await resource.signUrl(validUrl);
 
       expect(mockFetch).toHaveBeenCalledOnce();
       const [url, opts] = mockFetch.mock.calls[0];
@@ -61,7 +61,7 @@ describe('WebBotAuthResource', () => {
     it('returns the web_bot_auth block on success', async () => {
       mockFetchResponse(200, credentialsResponse);
 
-      const result = await resource.getHeaders(validUrl);
+      const result = await resource.signUrl(validUrl);
 
       expect(result).toEqual(webBotAuthBlock);
     });
@@ -69,8 +69,8 @@ describe('WebBotAuthResource', () => {
     it('caches result per authority and skips re-fetch for same hostname', async () => {
       mockFetchResponse(200, credentialsResponse);
 
-      const first = await resource.getHeaders(validUrl);
-      const second = await resource.getHeaders(
+      const first = await resource.signUrl(validUrl);
+      const second = await resource.signUrl(
         'https://wine-merchant.com/other-page',
       );
 
@@ -80,10 +80,10 @@ describe('WebBotAuthResource', () => {
 
     it('does not share cache across different authorities', async () => {
       mockFetchResponse(200, credentialsResponse);
-      await resource.getHeaders(validUrl);
+      await resource.signUrl(validUrl);
 
       mockFetchResponse(200, credentialsResponse);
-      await resource.getHeaders('https://other-merchant.com/page');
+      await resource.signUrl('https://other-merchant.com/page');
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
@@ -98,10 +98,10 @@ describe('WebBotAuthResource', () => {
         web_bot_auth: nearlyExpiredBlock,
       });
 
-      await resource.getHeaders(validUrl);
+      await resource.signUrl(validUrl);
 
       mockFetchResponse(200, credentialsResponse);
-      await resource.getHeaders(validUrl);
+      await resource.signUrl(validUrl);
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
@@ -109,8 +109,8 @@ describe('WebBotAuthResource', () => {
     it('does not re-fetch when cached entry is still fresh', async () => {
       mockFetchResponse(200, credentialsResponse);
 
-      await resource.getHeaders(validUrl);
-      await resource.getHeaders(validUrl);
+      await resource.signUrl(validUrl);
+      await resource.signUrl(validUrl);
 
       expect(mockFetch).toHaveBeenCalledOnce();
     });
@@ -126,7 +126,7 @@ describe('WebBotAuthResource', () => {
         .mockResolvedValueOnce('expired_token')
         .mockResolvedValueOnce('fresh_token');
 
-      const result = await resource.getHeaders(validUrl);
+      const result = await resource.signUrl(validUrl);
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
       const [, secondOpts] = mockFetch.mock.calls[1];
@@ -137,7 +137,7 @@ describe('WebBotAuthResource', () => {
     it('throws LinkApiError on HTTP error', async () => {
       mockFetchResponse(422, { error: 'Invalid URL' });
 
-      const err = await resource.getHeaders(validUrl).catch((e) => e);
+      const err = await resource.signUrl(validUrl).catch((e) => e);
       expect(err).toBeInstanceOf(LinkApiError);
       expect(err.message).toMatch('Failed to get web bot auth headers (422)');
     });
@@ -148,7 +148,7 @@ describe('WebBotAuthResource', () => {
         web_bot_auth: { ...webBotAuthBlock, expires_at: 'not-a-date' },
       });
 
-      const err = await resource.getHeaders(validUrl).catch((e) => e);
+      const err = await resource.signUrl(validUrl).catch((e) => e);
       expect(err).toBeInstanceOf(LinkSdkError);
       expect(err.message).toMatch('invalid expires_at');
     });
@@ -156,23 +156,21 @@ describe('WebBotAuthResource', () => {
     it('throws LinkSdkError when response is missing web_bot_auth block', async () => {
       mockFetchResponse(200, { identity_token: 'tok_test123' });
 
-      const err = await resource.getHeaders(validUrl).catch((e) => e);
+      const err = await resource.signUrl(validUrl).catch((e) => e);
       expect(err).toBeInstanceOf(LinkSdkError);
-      expect(err.message).toMatch(
-        'Sign response missing web_bot_auth block',
-      );
+      expect(err.message).toMatch('Sign response missing web_bot_auth block');
     });
 
     it('throws when access token is unavailable', async () => {
       getAccessToken.mockRejectedValueOnce(new Error('Missing access token'));
 
-      await expect(resource.getHeaders(validUrl)).rejects.toThrow(
+      await expect(resource.signUrl(validUrl)).rejects.toThrow(
         'Missing access token',
       );
     });
 
     it('throws LinkSdkError on invalid URL', async () => {
-      const err = await resource.getHeaders('not-a-url').catch((e) => e);
+      const err = await resource.signUrl('not-a-url').catch((e) => e);
       expect(err).toBeInstanceOf(LinkSdkError);
       expect(err.message).toMatch('Invalid URL');
     });

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -89,5 +89,5 @@ export interface IUserInfoResource {
 }
 
 export interface IWebBotAuthResource {
-  getHeaders(url: string): Promise<WebBotAuthBlock>;
+  signUrl(url: string): Promise<WebBotAuthBlock>;
 }

--- a/packages/sdk/src/resources/web-bot-auth.ts
+++ b/packages/sdk/src/resources/web-bot-auth.ts
@@ -31,7 +31,7 @@ export class WebBotAuthResource implements IWebBotAuthResource {
   private readonly verbose: boolean;
   private readonly getAccessToken: AccessTokenProvider;
   private readonly fetchImpl: typeof globalThis.fetch;
-  private readonly credentialsEndpoint: string;
+  private readonly signEndpoint: string;
   private readonly logger: { debug(message: string): void };
   private readonly cache = new Map<string, CacheEntry>();
 
@@ -42,7 +42,7 @@ export class WebBotAuthResource implements IWebBotAuthResource {
     // defaultHeaders (if any) are baked into config.fetch by resolveLinkSdkConfig
     // via createDefaultHeadersFetch — no separate field needed.
     this.fetchImpl = requireFetchImplementation(config);
-    this.credentialsEndpoint = `${config.apiBaseUrl}/v1/agent_identity/credentials`;
+    this.signEndpoint = `${config.apiBaseUrl}/web_bot_auth/sign`;
     this.logger = config.logger;
   }
 
@@ -129,8 +129,8 @@ export class WebBotAuthResource implements IWebBotAuthResource {
    * the merchant site.
    *
    * @throws {LinkSdkError} if `url` is not a valid URL
-   * @throws {LinkSdkError} if the credentials response is missing the web_bot_auth block
-   * @throws {LinkApiError} if the credentials endpoint returns a non-2xx status
+   * @throws {LinkSdkError} if the sign response is missing the web_bot_auth block
+   * @throws {LinkApiError} if the sign endpoint returns a non-2xx status
    * @throws {LinkTransportError} if the network request fails
    */
   async getHeaders(url: string): Promise<WebBotAuthBlock> {
@@ -148,7 +148,7 @@ export class WebBotAuthResource implements IWebBotAuthResource {
 
     const { status, data, rawBody } = await this.apiFetch({
       method: 'POST',
-      url: this.credentialsEndpoint,
+      url: this.signEndpoint,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ url }),
     });
@@ -169,7 +169,7 @@ export class WebBotAuthResource implements IWebBotAuthResource {
     const webBotAuth = body?.web_bot_auth as WebBotAuthBlock | undefined;
     if (!webBotAuth) {
       throw new LinkSdkError(
-        `Credentials response missing web_bot_auth block (status ${status})`,
+        `Sign response missing web_bot_auth block (status ${status})`,
       );
     }
 

--- a/packages/sdk/src/resources/web-bot-auth.ts
+++ b/packages/sdk/src/resources/web-bot-auth.ts
@@ -133,7 +133,7 @@ export class WebBotAuthResource implements IWebBotAuthResource {
    * @throws {LinkApiError} if the sign endpoint returns a non-2xx status
    * @throws {LinkTransportError} if the network request fails
    */
-  async getHeaders(url: string): Promise<WebBotAuthBlock> {
+  async signUrl(url: string): Promise<WebBotAuthBlock> {
     let authority: string;
     try {
       authority = new URL(url).hostname;


### PR DESCRIPTION
## Motivation

Web Bot Auth signing now has a dedicated endpoint `POST /web_bot_auth/sign`  rather than being bundled into another endpoint.

The `WebBotAuthResource` SDK class (added in #105) was pointing at the old combined endpoint. This PR updates it to call the dedicated signing endpoint, keeping the SDK in sync with the current API.

## What changed

**`packages/sdk/src/resources/web-bot-auth.ts`**
- `credentialsEndpoint` renamed to `signEndpoint`
- Endpoint URL updated: `${apiBaseUrl}/v1/agent_identity/credentials` => `${apiBaseUrl}/web_bot_auth/sign`
- JSDoc and error messages updated to reflect the new endpoint

**`packages/sdk/src/resources/__tests__/web-bot-auth.test.ts`**
- URL assertion updated to `https://api.link.com/web_bot_auth/sign`
- Test fixture updated to remove `identity_token`: the signing endpoint returns `{ web_bot_auth: {...} }` only
- Error message assertion updated to match

## What did not change

The response parsing logic is unchanged. The signing endpoint wraps the signature block identically to before: `{ "web_bot_auth": { signature, signature_input, signature_agent, authority, expires_at } }`. The request body is also unchanged: `{ "url": "<target url>" }`.

There is no behavior change for callers of `WebBotAuthResource.getHeaders()`.

## Test plan

- [x] updated tests