### PR TITLE
Add payment_status_details to spend request retrieve

### DIFF
--- a/packages/cli/src/commands/spend-request/retrieve.tsx
+++ b/packages/cli/src/commands/spend-request/retrieve.tsx
@@ -268,9 +268,7 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
               {psd.created && (
                 <Text>
                   {'  '}Charged At:{' '}
-                  <Text bold>
-                    {new Date(psd.created * 1000).toISOString()}
-                  </Text>
+                  <Text bold>{new Date(psd.created * 1000).toISOString()}</Text>
                 </Text>
               )}
               {psd.refund_details && (

--- a/packages/cli/src/commands/spend-request/retrieve.tsx
+++ b/packages/cli/src/commands/spend-request/retrieve.tsx
@@ -227,6 +227,7 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
   }
 
   if (phase === 'finalized') {
+    const psd = request?.payment_status_details;
     return (
       <Box flexDirection="column">
         <Text color="yellow">
@@ -239,6 +240,55 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
           <Text>
             Status: <Text bold>{request?.status}</Text>
           </Text>
+          {psd && (
+            <Box flexDirection="column" marginTop={1}>
+              <Text bold>Payment Details:</Text>
+              <Text>
+                {'  '}Outcome:{' '}
+                <Text bold color={psd.outcome === 'success' ? 'green' : 'red'}>
+                  {psd.outcome}
+                </Text>
+              </Text>
+              {psd.code && (
+                <Text>
+                  {'  '}Code: <Text bold>{psd.code}</Text>
+                </Text>
+              )}
+              {psd.decline_code && (
+                <Text>
+                  {'  '}Decline Reason: <Text bold>{psd.decline_code}</Text>
+                </Text>
+              )}
+              <Text>
+                {'  '}Amount:{' '}
+                <Text bold>
+                  {psd.amount} {psd.currency}
+                </Text>
+              </Text>
+              {psd.created && (
+                <Text>
+                  {'  '}Charged At:{' '}
+                  <Text bold>
+                    {new Date(psd.created * 1000).toISOString()}
+                  </Text>
+                </Text>
+              )}
+              {psd.refund_details && (
+                <Box flexDirection="column" marginTop={1}>
+                  <Text bold>{'  '}Refund:</Text>
+                  <Text>
+                    {'    '}Amount:{' '}
+                    <Text bold>
+                      {psd.refund_details.amount} {psd.refund_details.currency}
+                    </Text>
+                  </Text>
+                  <Text>
+                    {'    '}State: <Text bold>{psd.refund_details.state}</Text>
+                  </Text>
+                </Box>
+              )}
+            </Box>
+          )}
         </Box>
       </Box>
     );
@@ -300,6 +350,36 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
             {request?.line_items.map((li) => li.name).join(', ')}
           </Text>
         </Text>
+        {request?.payment_status_details && (
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold>Last Payment Attempt:</Text>
+            <Text>
+              {'  '}Outcome:{' '}
+              <Text
+                bold
+                color={
+                  request.payment_status_details.outcome === 'success'
+                    ? 'green'
+                    : 'red'
+                }
+              >
+                {request.payment_status_details.outcome}
+              </Text>
+            </Text>
+            {request.payment_status_details.code && (
+              <Text>
+                {'  '}Code:{' '}
+                <Text bold>{request.payment_status_details.code}</Text>
+              </Text>
+            )}
+            {request.payment_status_details.decline_code && (
+              <Text>
+                {'  '}Decline Reason:{' '}
+                <Text bold>{request.payment_status_details.decline_code}</Text>
+              </Text>
+            )}
+          </Box>
+        )}
         {request?.shared_payment_token && (
           <Box flexDirection="column" marginTop={1}>
             <Text bold>

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -73,6 +73,23 @@ export interface SharedPaymentToken {
   valid_until?: string;
 }
 
+export interface RefundDetails {
+  amount: number;
+  currency: string;
+  state: string;
+  created: number;
+}
+
+export interface PaymentStatusDetails {
+  outcome: 'success' | 'failure';
+  code?: string | null;
+  decline_code?: string | null;
+  amount: number;
+  currency: string;
+  created?: number | null;
+  refund_details?: RefundDetails | null;
+}
+
 export interface SpendRequest {
   id: string;
   merchant_name?: string;
@@ -90,6 +107,7 @@ export interface SpendRequest {
   approval_url?: string;
   card?: Card;
   shared_payment_token?: SharedPaymentToken;
+  payment_status_details?: PaymentStatusDetails | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
- Add PaymentStatusDetails and RefundDetails types to the SDK and display them in the CLI's retrieve command.
- SDK changes:
  - Add RefundDetails interface (amount, currency, state, created)
  - Add PaymentStatusDetails interface (outcome, code, decline_code, amount, currency, created, refund_details)
  - Add optional payment_status_details field to SpendRequest
- CLI changes:
  - finalized phase (expired/canceled/failed/succeeded): render outcome with colour coding, error code, decline reason, charged amount/currency, timestamp, and refund block when present
  - success phase (approved): show a "Last Payment Attempt" section when payment_status_details is present, indicating a failed payment attempt on an otherwise still-approved request