### PR TITLE
feat: clear any existing auth when calling auth login

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -976,8 +976,67 @@ describe('production mode', () => {
       expect(next.until).toContain('authenticated');
     });
 
+    it('revokes existing session before starting new login', async () => {
+      setResponseForUrl('/device/revoke', 200, 'ok');
+      setResponseForUrl('/device/code', 200, DEVICE_CODE_RESPONSE);
+
+      const result = await runProdCli(
+        'auth',
+        'login',
+        '--client-name',
+        'New Agent',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      const revokeRequest = requests.find((r) =>
+        r.url.includes('/device/revoke'),
+      );
+      expect(revokeRequest).toBeDefined();
+      expect(revokeRequest?.method).toBe('POST');
+      const params = new URLSearchParams(revokeRequest?.body);
+      expect(params.get('token')).toBe(PROD_AUTH_TOKENS.refresh_token);
+    });
+
+    it('proceeds with login even if revoke fails', async () => {
+      setResponseForUrl('/device/revoke', 500, { error: 'server_error' });
+      setResponseForUrl('/device/code', 200, DEVICE_CODE_RESPONSE);
+
+      const result = await runProdCli(
+        'auth',
+        'login',
+        '--client-name',
+        'New Agent',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      const output = parseJson(result.stdout) as Record<string, unknown>[];
+      expect(output[0].verification_url).toBeDefined();
+    });
+
+    it('skips revoke when not previously authenticated', async () => {
+      storage.clearAuth();
+      setResponseForUrl('/device/code', 200, DEVICE_CODE_RESPONSE);
+
+      const result = await runProdCli(
+        'auth',
+        'login',
+        '--client-name',
+        'Fresh Agent',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      const revokeRequest = requests.find((r) =>
+        r.url.includes('/device/revoke'),
+      );
+      expect(revokeRequest).toBeUndefined();
+    });
+
     it('with --interval, yields code first then polls until authenticated', async () => {
       storage.clearAuth();
+      setResponseForUrl('/device/revoke', 200, 'ok');
       setResponseForUrl('/device/code', 200, DEVICE_CODE_RESPONSE);
       setResponseForUrl('/device/token', 200, TOKEN_RESPONSE);
 
@@ -1032,6 +1091,7 @@ describe('production mode', () => {
 
     it('with --interval, exits with error on access_denied', async () => {
       storage.clearAuth();
+      setResponseForUrl('/device/revoke', 200, 'ok');
       setResponseForUrl('/device/code', 200, DEVICE_CODE_RESPONSE);
       setResponseForUrl('/device/token', 400, { error: 'access_denied' });
 

--- a/packages/cli/src/commands/auth/index.tsx
+++ b/packages/cli/src/commands/auth/index.tsx
@@ -73,6 +73,22 @@ async function* pollAuthStatus(
   }
 }
 
+async function maybeRevokeAndClearAuth(
+  authResource: IAuthResource,
+  storage: AuthStorage,
+) {
+  const auth = storage.getAuth();
+  if (auth?.refresh_token) {
+    try {
+      await authResource.revokeToken(auth.refresh_token);
+    } catch {
+      // best-effort: clear local storage regardless
+    }
+  }
+  storage.clearAuth();
+  storage.clearPendingDeviceAuth();
+}
+
 export function createAuthCli(
   authResource: IAuthResource,
   getUpdateInfo?: UpdateInfoProvider,
@@ -96,6 +112,8 @@ export function createAuthCli(
           message: 'client-name must be a non-empty string',
         });
       }
+
+      await maybeRevokeAndClearAuth(authResource, storage);
 
       if (!c.agent && !c.formatExplicit) {
         return renderInteractive(
@@ -154,16 +172,7 @@ export function createAuthCli(
     description: 'Log out from Link',
     outputPolicy: 'agent-only' as const,
     async run(c) {
-      const auth = storage.getAuth();
-      if (auth?.refresh_token) {
-        try {
-          await authResource.revokeToken(auth.refresh_token);
-        } catch {
-          // best-effort: clear local storage regardless
-        }
-      }
-      storage.clearAuth();
-      storage.clearPendingDeviceAuth();
+      await maybeRevokeAndClearAuth(authResource, storage);
       storage.deleteConfig();
       const result = { authenticated: false };
 


### PR DESCRIPTION
When calling `link-cli auth login`, ensure we revoke/clear any pre-existing auth credentials


https://github.com/user-attachments/assets/31983f0d-00fa-4a7f-8ce4-b7d4dcfd9714

