### PR TITLE
Support additional endpoints to auth by env access_token

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -102,6 +102,13 @@ function setResponseForUrl(url: string, status: number, body: unknown) {
 }
 
 async function runProdCli(...args: string[]): Promise<CliResult> {
+  return runProdCliWithEnv({}, ...args);
+}
+
+async function runProdCliWithEnv(
+  extraEnv: Record<string, string>,
+  ...args: string[]
+): Promise<CliResult> {
   try {
     const { stdout, stderr } = await execFileAsync(
       'node',
@@ -112,6 +119,7 @@ async function runProdCli(...args: string[]): Promise<CliResult> {
           LINK_API_BASE_URL: `http://127.0.0.1:${serverPort}`,
           LINK_AUTH_BASE_URL: `http://127.0.0.1:${serverPort}`,
           XDG_DATA_HOME: '/tmp/link-cli-test-empty',
+          ...extraEnv,
         },
         timeout: 10_000,
       },
@@ -1184,6 +1192,92 @@ describe('production mode', () => {
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
       expect(output).toContain('Not authenticated');
+    });
+  });
+
+  describe('LINK_ACCESS_TOKEN', () => {
+    const ENV_TOKEN = 'env_access_token_abc123';
+
+    beforeEach(() => {
+      storage.clearAuth();
+    });
+
+    it('allows user-info retrieve with no stored auth', async () => {
+      setResponseForUrl('/userinfo', 200, {
+        email: 'user@example.com',
+        name: 'Test User',
+      });
+
+      const result = await runProdCliWithEnv(
+        { LINK_ACCESS_TOKEN: ENV_TOKEN },
+        'user-info',
+        'retrieve',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      const output = parseJson(result.stdout) as Record<string, unknown>;
+      expect(output.email).toBe('user@example.com');
+      const userInfoRequest = requests.find((r) => r.url === '/userinfo');
+      expect(userInfoRequest).toBeDefined();
+      expect(userInfoRequest?.headers.authorization).toBe(`Bearer ${ENV_TOKEN}`);
+    });
+
+    it('allows spend-request list with no stored auth', async () => {
+      setNextResponse(200, { data: [] });
+
+      const result = await runProdCliWithEnv(
+        { LINK_ACCESS_TOKEN: ENV_TOKEN },
+        'spend-request',
+        'list',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      const spendRequest = requests.find((r) => r.url === '/spend_requests');
+      expect(spendRequest).toBeDefined();
+      expect(spendRequest?.headers.authorization).toBe(`Bearer ${ENV_TOKEN}`);
+    });
+
+    it('allows payment-methods list with no stored auth', async () => {
+      setResponseForUrl('/payment-details', 200, { payment_details: [] });
+
+      const result = await runProdCliWithEnv(
+        { LINK_ACCESS_TOKEN: ENV_TOKEN },
+        'payment-methods',
+        'list',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      const pmRequest = requests.find((r) => r.url === '/payment-details');
+      expect(pmRequest).toBeDefined();
+      expect(pmRequest?.headers.authorization).toBe(`Bearer ${ENV_TOKEN}`);
+    });
+
+    it('allows shipping-address list with no stored auth', async () => {
+      setResponseForUrl('/shipping_addresses', 200, { shipping_addresses: [] });
+
+      const result = await runProdCliWithEnv(
+        { LINK_ACCESS_TOKEN: ENV_TOKEN },
+        'shipping-address',
+        'list',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      const saRequest = requests.find((r) => r.url === '/shipping_addresses');
+      expect(saRequest).toBeDefined();
+      expect(saRequest?.headers.authorization).toBe(`Bearer ${ENV_TOKEN}`);
+    });
+
+    it('still blocks commands with neither stored auth nor env token', async () => {
+      const result = await runProdCliWithEnv({}, 'user-info', 'retrieve', '--json');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain('Not authenticated');
+      const userInfoRequest = requests.find((r) => r.url === '/userinfo');
+      expect(userInfoRequest).toBeUndefined();
     });
   });
 

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1220,7 +1220,9 @@ describe('production mode', () => {
       expect(output.email).toBe('user@example.com');
       const userInfoRequest = requests.find((r) => r.url === '/userinfo');
       expect(userInfoRequest).toBeDefined();
-      expect(userInfoRequest?.headers.authorization).toBe(`Bearer ${ENV_TOKEN}`);
+      expect(userInfoRequest?.headers.authorization).toBe(
+        `Bearer ${ENV_TOKEN}`,
+      );
     });
 
     it('allows spend-request list with no stored auth', async () => {
@@ -1272,7 +1274,12 @@ describe('production mode', () => {
     });
 
     it('still blocks commands with neither stored auth nor env token', async () => {
-      const result = await runProdCliWithEnv({}, 'user-info', 'retrieve', '--json');
+      const result = await runProdCliWithEnv(
+        {},
+        'user-info',
+        'retrieve',
+        '--json',
+      );
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain('Not authenticated');

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -80,7 +80,9 @@ if (!isAgent && process.stdout.isTTY) {
 cli.command(
   createAuthCli(authRepo, getUpdateInfo, authStorage, envAccessToken),
 );
-cli.command(createSpendRequestCli(spendRequestRepo, authStorage, envAccessToken));
+cli.command(
+  createSpendRequestCli(spendRequestRepo, authStorage, envAccessToken),
+);
 cli.command(
   createPaymentMethodsCli(
     () => factory.createPaymentMethodsResource(),
@@ -96,7 +98,11 @@ cli.command(
   ),
 );
 cli.command(
-  createUserInfoCli(() => factory.createUserInfoResource(), authStorage, envAccessToken),
+  createUserInfoCli(
+    () => factory.createUserInfoResource(),
+    authStorage,
+    envAccessToken,
+  ),
 );
 cli.command(createMppCli(spendRequestRepo, authStorage, envAccessToken));
 // cli.command(

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -80,23 +80,25 @@ if (!isAgent && process.stdout.isTTY) {
 cli.command(
   createAuthCli(authRepo, getUpdateInfo, authStorage, envAccessToken),
 );
-cli.command(createSpendRequestCli(spendRequestRepo, authStorage));
+cli.command(createSpendRequestCli(spendRequestRepo, authStorage, envAccessToken));
 cli.command(
   createPaymentMethodsCli(
     () => factory.createPaymentMethodsResource(),
     authStorage,
+    envAccessToken,
   ),
 );
 cli.command(
   createShippingAddressCli(
     () => factory.createShippingAddressResource(),
     authStorage,
+    envAccessToken,
   ),
 );
 cli.command(
-  createUserInfoCli(() => factory.createUserInfoResource(), authStorage),
+  createUserInfoCli(() => factory.createUserInfoResource(), authStorage, envAccessToken),
 );
-cli.command(createMppCli(spendRequestRepo, authStorage));
+cli.command(createMppCli(spendRequestRepo, authStorage, envAccessToken));
 // cli.command(
 //   createWebBotAuthCli(() => factory.createWebBotAuthResource(), authStorage),
 // );

--- a/packages/cli/src/commands/mpp/index.tsx
+++ b/packages/cli/src/commands/mpp/index.tsx
@@ -11,6 +11,7 @@ import { decodeOptions, payOptions } from './schema';
 export function createMppCli(
   repository: ISpendRequestResource,
   authStorage?: AuthStorage,
+  envAccessToken?: string,
 ) {
   const cli = Cli.create('mpp', {
     description: 'Machine payment protocol (MPP) commands',
@@ -25,7 +26,7 @@ export function createMppCli(
     options: payOptions,
     alias: { method: 'X', data: 'd', header: 'H' },
     outputPolicy: 'agent-only' as const,
-    middleware: [requireAuth(authStorage)],
+    middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {
       const url = c.args.url;
       const opts = c.options;

--- a/packages/cli/src/commands/payment-methods/index.tsx
+++ b/packages/cli/src/commands/payment-methods/index.tsx
@@ -9,6 +9,7 @@ import { PaymentMethodsList } from './list';
 export function createPaymentMethodsCli(
   createResource: () => IPaymentMethodsResource,
   authStorage?: AuthStorage,
+  envAccessToken?: string,
 ) {
   const cli = Cli.create('payment-methods', {
     description: 'Payment methods management commands',
@@ -17,7 +18,7 @@ export function createPaymentMethodsCli(
   cli.command('list', {
     description: 'List all payment methods on your account',
     outputPolicy: 'agent-only' as const,
-    middleware: [requireAuth(authStorage)],
+    middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {
       const resource = createResource();
 
@@ -35,7 +36,7 @@ export function createPaymentMethodsCli(
   cli.command('add', {
     description: 'Open the Link wallet to add a new payment method',
     outputPolicy: 'agent-only' as const,
-    middleware: [requireAuth(authStorage)],
+    middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {
       if (!c.agent && !c.formatExplicit) {
         return renderInteractive(<AddPaymentMethod />, () => ({

--- a/packages/cli/src/commands/shipping-address/index.tsx
+++ b/packages/cli/src/commands/shipping-address/index.tsx
@@ -8,6 +8,7 @@ import { ShippingAddressList } from './list';
 export function createShippingAddressCli(
   createResource: () => IShippingAddressResource,
   authStorage?: AuthStorage,
+  envAccessToken?: string,
 ) {
   const cli = Cli.create('shipping-address', {
     description: 'Shipping address management commands',
@@ -16,7 +17,7 @@ export function createShippingAddressCli(
   cli.command('list', {
     description: 'List all shipping addresses on your account',
     outputPolicy: 'agent-only' as const,
-    middleware: [requireAuth(authStorage)],
+    middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {
       const resource = createResource();
 

--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -50,6 +50,7 @@ async function applyOutputFile(
 export function createSpendRequestCli(
   repository: ISpendRequestResource,
   authStorage?: AuthStorage,
+  envAccessToken?: string,
 ) {
   const cli = Cli.create('spend-request', {
     description: 'Spend request management commands',
@@ -59,7 +60,7 @@ export function createSpendRequestCli(
     description:
       'List active spend requests (created, pending_approval, approved)',
     outputPolicy: 'agent-only' as const,
-    middleware: [requireAuth(authStorage)],
+    middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {
       if (!c.agent && !c.formatExplicit) {
         return renderInteractive(
@@ -78,7 +79,7 @@ export function createSpendRequestCli(
     alias: { merchantName: 'm' },
     outputPolicy: 'agent-only' as const,
     async *run(c) {
-      requireAuthGuard(c, authStorage);
+      requireAuthGuard(c, authStorage, envAccessToken);
 
       const opts = c.options;
       const requestApproval = !!opts.requestApproval;
@@ -205,7 +206,7 @@ export function createSpendRequestCli(
     }),
     options: updateOptions,
     outputPolicy: 'agent-only' as const,
-    middleware: [requireAuth(authStorage)],
+    middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {
       const id = c.args.id;
       const opts = c.options;
@@ -258,7 +259,7 @@ export function createSpendRequestCli(
     }),
     outputPolicy: 'agent-only' as const,
     async *run(c) {
-      requireAuthGuard(c, authStorage);
+      requireAuthGuard(c, authStorage, envAccessToken);
 
       const id = c.args.id;
 
@@ -302,7 +303,7 @@ export function createSpendRequestCli(
     options: retrieveOptions,
     outputPolicy: 'agent-only' as const,
     async *run(c) {
-      requireAuthGuard(c, authStorage);
+      requireAuthGuard(c, authStorage, envAccessToken);
 
       const id = c.args.id;
       const opts = c.options;
@@ -401,7 +402,7 @@ export function createSpendRequestCli(
       id: z.string().describe('Spend request ID'),
     }),
     outputPolicy: 'agent-only' as const,
-    middleware: [requireAuth(authStorage)],
+    middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {
       const id = c.args.id;
 

--- a/packages/cli/src/commands/user-info/index.tsx
+++ b/packages/cli/src/commands/user-info/index.tsx
@@ -8,6 +8,7 @@ import { UserInfoRetrieve } from './retrieve';
 export function createUserInfoCli(
   createResource: () => IUserInfoResource,
   authStorage?: AuthStorage,
+  envAccessToken?: string,
 ) {
   const cli = Cli.create('user-info', {
     description: 'User information commands',
@@ -16,7 +17,7 @@ export function createUserInfoCli(
   cli.command('retrieve', {
     description: 'Retrieve user info (email, name, phone)',
     outputPolicy: 'agent-only' as const,
-    middleware: [requireAuth(authStorage)],
+    middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {
       const resource = createResource();
 

--- a/packages/cli/src/utils/__tests__/require-auth.test.ts
+++ b/packages/cli/src/utils/__tests__/require-auth.test.ts
@@ -16,7 +16,11 @@ function makeStorage(authenticated: boolean): AuthStorage {
 function makeContext() {
   const error = vi.fn();
   const next = vi.fn();
-  return { c: { error } as unknown as Parameters<ReturnType<typeof requireAuth>>[0], next, error };
+  return {
+    c: { error } as unknown as Parameters<ReturnType<typeof requireAuth>>[0],
+    next,
+    error,
+  };
 }
 
 describe('requireAuth', () => {
@@ -24,7 +28,9 @@ describe('requireAuth', () => {
     const { c, next, error } = makeContext();
     const handler = requireAuth(makeStorage(false));
     handler(c, next);
-    expect(error).toHaveBeenCalledWith(expect.objectContaining({ code: 'NOT_AUTHENTICATED' }));
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'NOT_AUTHENTICATED' }),
+    );
     expect(next).not.toHaveBeenCalled();
   });
 
@@ -55,20 +61,30 @@ describe('requireAuth', () => {
 
 describe('requireAuthGuard', () => {
   it('blocks when no stored auth and no env token', () => {
-    const error = vi.fn(() => { throw new Error('auth error'); });
-    expect(() => requireAuthGuard({ error } as never, makeStorage(false))).toThrow('auth error');
-    expect(error).toHaveBeenCalledWith(expect.objectContaining({ code: 'NOT_AUTHENTICATED' }));
+    const error = vi.fn(() => {
+      throw new Error('auth error');
+    });
+    expect(() =>
+      requireAuthGuard({ error } as never, makeStorage(false)),
+    ).toThrow('auth error');
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'NOT_AUTHENTICATED' }),
+    );
   });
 
   it('does not throw when stored auth is present', () => {
     const error = vi.fn();
-    expect(() => requireAuthGuard({ error } as never, makeStorage(true))).not.toThrow();
+    expect(() =>
+      requireAuthGuard({ error } as never, makeStorage(true)),
+    ).not.toThrow();
     expect(error).not.toHaveBeenCalled();
   });
 
   it('does not throw when envAccessToken is set with no stored auth', () => {
     const error = vi.fn();
-    expect(() => requireAuthGuard({ error } as never, makeStorage(false), 'tok_env_abc')).not.toThrow();
+    expect(() =>
+      requireAuthGuard({ error } as never, makeStorage(false), 'tok_env_abc'),
+    ).not.toThrow();
     expect(error).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/utils/__tests__/require-auth.test.ts
+++ b/packages/cli/src/utils/__tests__/require-auth.test.ts
@@ -1,0 +1,74 @@
+import type { AuthStorage } from '@stripe/link-sdk';
+import { describe, expect, it, vi } from 'vitest';
+import { requireAuth, requireAuthGuard } from '../require-auth';
+
+function makeStorage(authenticated: boolean): AuthStorage {
+  return {
+    isAuthenticated: vi.fn(() => authenticated),
+    getAuth: vi.fn(() => null),
+    setAuth: vi.fn(),
+    clearAuth: vi.fn(),
+    clearAll: vi.fn(),
+    getPath: vi.fn(() => '/tmp/fake'),
+  } as unknown as AuthStorage;
+}
+
+function makeContext() {
+  const error = vi.fn();
+  const next = vi.fn();
+  return { c: { error } as unknown as Parameters<ReturnType<typeof requireAuth>>[0], next, error };
+}
+
+describe('requireAuth', () => {
+  it('blocks when no stored auth and no env token', () => {
+    const { c, next, error } = makeContext();
+    const handler = requireAuth(makeStorage(false));
+    handler(c, next);
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ code: 'NOT_AUTHENTICATED' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows when stored auth is present', () => {
+    const { c, next, error } = makeContext();
+    const handler = requireAuth(makeStorage(true));
+    handler(c, next);
+    expect(error).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('allows when envAccessToken is set even with no stored auth', () => {
+    const { c, next, error } = makeContext();
+    const handler = requireAuth(makeStorage(false), 'tok_env_abc');
+    handler(c, next);
+    expect(error).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('allows when both envAccessToken and stored auth are present', () => {
+    const { c, next, error } = makeContext();
+    const handler = requireAuth(makeStorage(true), 'tok_env_abc');
+    handler(c, next);
+    expect(error).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+  });
+});
+
+describe('requireAuthGuard', () => {
+  it('blocks when no stored auth and no env token', () => {
+    const error = vi.fn(() => { throw new Error('auth error'); });
+    expect(() => requireAuthGuard({ error } as never, makeStorage(false))).toThrow('auth error');
+    expect(error).toHaveBeenCalledWith(expect.objectContaining({ code: 'NOT_AUTHENTICATED' }));
+  });
+
+  it('does not throw when stored auth is present', () => {
+    const error = vi.fn();
+    expect(() => requireAuthGuard({ error } as never, makeStorage(true))).not.toThrow();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when envAccessToken is set with no stored auth', () => {
+    const error = vi.fn();
+    expect(() => requireAuthGuard({ error } as never, makeStorage(false), 'tok_env_abc')).not.toThrow();
+    expect(error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/utils/require-auth.ts
+++ b/packages/cli/src/utils/require-auth.ts
@@ -16,10 +16,10 @@ export const NOT_AUTHENTICATED_ERROR: AuthErrorOptions = {
   },
 };
 
-export function requireAuth(authStorage?: AuthStorage): MiddlewareHandler {
+export function requireAuth(authStorage?: AuthStorage, envAccessToken?: string): MiddlewareHandler {
   const store = authStorage ?? defaultStorage;
   return (c, next) => {
-    if (!store.isAuthenticated()) {
+    if (!envAccessToken && !store.isAuthenticated()) {
       return c.error(NOT_AUTHENTICATED_ERROR);
     }
     return next();
@@ -29,9 +29,10 @@ export function requireAuth(authStorage?: AuthStorage): MiddlewareHandler {
 export function requireAuthGuard(
   c: { error: (err: AuthErrorOptions) => never },
   authStorage?: AuthStorage,
+  envAccessToken?: string,
 ) {
   const store = authStorage ?? defaultStorage;
-  if (!store.isAuthenticated()) {
+  if (!envAccessToken && !store.isAuthenticated()) {
     c.error(NOT_AUTHENTICATED_ERROR);
   }
 }

--- a/packages/cli/src/utils/require-auth.ts
+++ b/packages/cli/src/utils/require-auth.ts
@@ -16,7 +16,10 @@ export const NOT_AUTHENTICATED_ERROR: AuthErrorOptions = {
   },
 };
 
-export function requireAuth(authStorage?: AuthStorage, envAccessToken?: string): MiddlewareHandler {
+export function requireAuth(
+  authStorage?: AuthStorage,
+  envAccessToken?: string,
+): MiddlewareHandler {
   const store = authStorage ?? defaultStorage;
   return (c, next) => {
     if (!envAccessToken && !store.isAuthenticated()) {


### PR DESCRIPTION
There is a previous change to load OAuth access_token through env variable for auth but that only worked for spendRequest creation. This pr pipes that access_token through for other requests as well

<img width="981" height="176" alt="CleanShot 2026-06-02 at 09 16 58" src="https://github.com/user-attachments/assets/63dbbe65-f11a-4d68-b938-1be88dc0f052" />