### PR TITLE
[Link Agent Wallet] Add report command for agent observability

### DIFF
--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -5,6 +5,7 @@ import { createDemoCli } from './commands/demo';
 import { createMppCli } from './commands/mpp';
 import { createOnboardCli } from './commands/onboard';
 import { createPaymentMethodsCli } from './commands/payment-methods';
+import { createReportCli } from './commands/report';
 import { createServeCli } from './commands/serve';
 import { createShippingAddressCli } from './commands/shipping-address';
 import { createSpendRequestCli } from './commands/spend-request';
@@ -108,6 +109,13 @@ cli.command(createMppCli(spendRequestRepo, authStorage, envAccessToken));
 // cli.command(
 //   createWebBotAuthCli(() => factory.createWebBotAuthResource(), authStorage),
 // );
+cli.command(
+  createReportCli(
+    () => factory.createReportResource(),
+    authStorage,
+    envAccessToken,
+  ),
+);
 cli.command(
   createDemoCli(
     authRepo,

--- a/packages/cli/src/commands/report/index.tsx
+++ b/packages/cli/src/commands/report/index.tsx
@@ -1,0 +1,36 @@
+import type { AuthStorage, IReportResource } from '@stripe/link-sdk';
+import { Cli } from 'incur';
+import { requireAuth } from '../../utils/require-auth';
+import { reportOptions } from './schema';
+
+export function createReportCli(
+  createResource: () => IReportResource,
+  authStorage?: AuthStorage,
+  envAccessToken?: string,
+) {
+  const cli = Cli.create('report', {
+    description: 'Report the outcome of a purchase attempt',
+  });
+
+  cli.command('', {
+    description:
+      'Report the outcome of an agent action on a domain. Call after every purchase attempt.',
+    options: reportOptions,
+    outputPolicy: 'agent-only' as const,
+    middleware: [requireAuth(authStorage, envAccessToken)],
+    async run(c) {
+      const resource = createResource();
+      const result = await resource.create({
+        domain: c.options.domain,
+        outcome: c.options.outcome,
+        spend_request_id: c.options.spendRequestId,
+        tags: c.options.tag,
+        step: c.options.step,
+        freeform_context: c.options.freeformContext,
+      });
+      return result;
+    },
+  });
+
+  return cli;
+}

--- a/packages/cli/src/commands/report/index.tsx
+++ b/packages/cli/src/commands/report/index.tsx
@@ -1,6 +1,6 @@
 import type { AuthStorage, IReportResource } from '@stripe/link-sdk';
 import { Cli } from 'incur';
-import { requireAuth } from '../../utils/require-auth';
+import { requireAuthGuard } from '../../utils/require-auth';
 import { reportOptions } from './schema';
 
 export function createReportCli(
@@ -9,16 +9,12 @@ export function createReportCli(
   envAccessToken?: string,
 ) {
   const cli = Cli.create('report', {
-    description: 'Report the outcome of a purchase attempt',
-  });
-
-  cli.command('', {
     description:
       'Report the outcome of an agent action on a domain. Call after every purchase attempt.',
     options: reportOptions,
     outputPolicy: 'agent-only' as const,
-    middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {
+      requireAuthGuard(c, authStorage, envAccessToken);
       const resource = createResource();
       const result = await resource.create({
         domain: c.options.domain,

--- a/packages/cli/src/commands/report/schema.ts
+++ b/packages/cli/src/commands/report/schema.ts
@@ -1,0 +1,24 @@
+import { REPORT_OUTCOMES, REPORT_TAGS } from '@stripe/link-sdk';
+import { z } from 'incur';
+
+export const reportOptions = z.object({
+  domain: z.string().describe('Domain where the outcome occurred'),
+  outcome: z
+    .enum(REPORT_OUTCOMES)
+    .describe('What happened: success, blocked, or abandoned'),
+  spendRequestId: z.string().describe('Spend request ID (lsrq_...)'),
+  tag: z
+    .array(z.enum(REPORT_TAGS))
+    .optional()
+    .describe('Outcome tags (repeatable)'),
+  step: z
+    .string()
+    .max(500)
+    .optional()
+    .describe('Where in the flow the agent was'),
+  freeformContext: z
+    .string()
+    .max(500)
+    .optional()
+    .describe('Additional context (max 500 chars)'),
+});

--- a/packages/cli/src/utils/resource-factory.ts
+++ b/packages/cli/src/utils/resource-factory.ts
@@ -1,12 +1,14 @@
 import {
   type AuthStorage,
   type IPaymentMethodsResource,
+  type IReportResource,
   type IShippingAddressResource,
   type ISpendRequestResource,
   type IUserInfoResource,
   type IWebBotAuthResource,
   LinkAuthenticationError,
   PaymentMethodsResource,
+  ReportResource,
   ShippingAddressResource,
   SpendRequestResource,
   UserInfoResource,
@@ -78,6 +80,7 @@ export class ResourceFactory {
   private shippingAddressResource?: IShippingAddressResource;
   private userInfoResource?: IUserInfoResource;
   private webBotAuthResource?: IWebBotAuthResource;
+  private reportResource?: IReportResource;
 
   constructor(options: ResourceFactoryOptions = {}) {
     this.verbose = options.verbose ?? false;
@@ -229,5 +232,22 @@ export class ResourceFactory {
     );
 
     return this.webBotAuthResource;
+  }
+
+  createReportResource(): IReportResource {
+    if (this.reportResource) {
+      return this.reportResource;
+    }
+
+    const getAccessToken = this.createSdkAccessTokenProvider();
+    this.reportResource = sanitizeResource(
+      new ReportResource({
+        verbose: this.verbose,
+        defaultHeaders: this.defaultHeaders,
+        getAccessToken,
+      }),
+    );
+
+    return this.reportResource;
   }
 }


### PR DESCRIPTION
## Summary

Adds `link-cli report` command for reporting purchase outcomes. Agents call this after every purchase attempt to record what happened (success, blocked, abandoned) along with structured tags and context.

```bash
link-cli report \
  --domain merchant.com \
  --outcome blocked \
  --spend-request-id lsrq_abc123 \
  --tag captcha \
  --step "checkout payment form" \
  --freeform-context "Challenge appeared after clicking Place Order"
```

### Changes
- `packages/cli/src/commands/report/schema.ts` — Zod schema importing `REPORT_OUTCOMES`/`REPORT_TAGS` from SDK with `.max(500)` on freeform fields
- `packages/cli/src/commands/report/index.tsx` — Command definition using incur
- `packages/cli/src/utils/resource-factory.ts` — Add `createReportResource()`
- `packages/cli/src/cli.tsx` — Register the command

The command uses `outputPolicy: 'agent-only'` and is automatically exposed as an MCP tool when running with `--mcp`.

## Dependencies

Requires the SDK PR (merged): https://github.com/stripe/link-cli/pull/114

Server endpoint (merged): https://git.corp.stripe.com/stripe-internal/mint/pull/2186497 — `POST /agent_observations` in linkapi-srv, gated by the `enable_agent_observability_api` feature flag (returns 404 when disabled).

## Test plan

- [x] `link-cli report --help` shows options
- [x] `link-cli --mcp` exposes `report` as a tool
- [x] Manual test against the live endpoint

## Live test results

Tested the built CLI (`node packages/cli/dist/cli.js`) against the production endpoint at `https://api.link.com/agent_observations`.

**Setup.** Created a testmode spend request `lsrq_1ThGMWRoPKoROpAEW69PULZX`. The endpoint is gated by `enable_agent_observability_api`; the flag was enabled for the test consumer account `acct_1TVyy4RoPKoROpAE` (looked up from email via the `consumer.consumer_info` Hubble dataset).

### 1. Flag disabled returns 404

Before enabling the flag, the endpoint returned the flag-gate 404. Confirmed against the route source, which calls `halt_with_error(status: 404, message: "Not found")` when the flag is off.

```
Failed to create report (404): Not found
```

### 2. Success path returns 201 with `agent_report` body

`blocked` outcome with tags, step, and freeform context:

```bash
link-cli report --domain merchant.example.com --outcome blocked \
  --spend-request-id lsrq_1ThGMWRoPKoROpAEW69PULZX \
  --tag captcha --tag waf_block \
  --step "checkout payment form" \
  --freeform-context "Challenge appeared after clicking Place Order" \
  --format json
```

```json
{
  "object": "agent_report",
  "created_at": "2026-06-11T22:02:43Z",
  "domain": "merchant.example.com",
  "outcome": "blocked",
  "spend_request_id": "lsrq_1ThGMWRoPKoROpAEW69PULZX",
  "status": "received"
}
```

`success` outcome with a single tag and required fields only:

```json
{
  "object": "agent_report",
  "created_at": "2026-06-11T22:03:46Z",
  "domain": "merchant.example.com",
  "outcome": "success",
  "spend_request_id": "lsrq_1ThGMWRoPKoROpAEW69PULZX",
  "status": "received"
}
```

`abandoned` outcome (via MCP `report` tool, required fields plus step):

```json
{
  "object": "agent_report",
  "created_at": "2026-06-11T21:58:18Z",
  "domain": "y.com",
  "outcome": "abandoned",
  "spend_request_id": "lsrq_1ThGMWRoPKoROpAEW69PULZX",
  "status": "received"
}
```

### 3. Validation

Invalid tag is rejected client-side by the Zod enum before any request goes out:

```
Input validation error: Invalid arguments for tool report_: tag.0: Invalid option:
expected one of "stripe_checkout"|"captcha"|"anti_bot_script"|"cdn_block"|"waf_block"|
"dns_block"|"rate_limited"|"login_required"|"3ds_challenge"|"page_inaccessible"|
"timeout"|"site_error"|"payment_declined"|"other"
```

A `spend_request_id` without the `lsrq_` prefix reaches the server and is rejected with a 400 (the route's `start_with?("lsrq_")` check):

```
Failed to create report (400): spend_request_id is required
```

### 4. Auth gating

Unauthenticated request (empty auth store) is blocked before hitting the API:

```json
{
  "code": "UNKNOWN",
  "message": "Not authenticated. Run \"link-cli auth login\" first."
}
```


### 5. End-to-end verification (events land in Hubble)

After the EventBus → Falcon SIA archival was set up for `AgentObservabilityEvent` (dataset onboarding: https://git.corp.stripe.com/stripe-internal/mint/pull/2268838, subscription: https://git.corp.stripe.com/stripe-internal/mint/pull/2264277), the three reports below were sent through the CLI and confirmed to flow all the way into the warehouse:

`link-cli report` → `POST /agent_observations` (linkapi-srv) → EventBus → Falcon SIA → `icecube.eventbus_events.agent_observability_reports_raw`.

Reports sent:

| created_at (UTC) | domain | outcome | tags | step | freeform_context |
|---|---|---|---|---|---|
| 2026-06-16T20:12:30Z | merchant.example.com | `blocked` | `["captcha","waf_block"]` | checkout payment form | Challenge appeared after clicking Place Order |
| 2026-06-16T20:12:31Z | shop.example.com | `success` | `[]` | — | — |
| 2026-06-16T20:12:32Z | cart.example.com | `abandoned` | `[]` | shipping address entry | — |

All three appear in the Iceberg table with every field intact (`consumer_account_id`, `livemode = true`, tags, step, freeform_context). The CloudEvent metadata confirms each leg of the pipeline:
- `datacontenttype: application/protobuf`, `dataschema: proto://com.stripe.consumer.agent_wallet.AgentObservabilityEvent`
- `stripesubscriptionfqn: default.default.com_stripe_consumer_agent_wallet_agentobservabilityevent_internal_export`
- `stripedfcomputation: linkapi-srv.POST /agent_observations`

Hubble query (proof): https://hubble.corp.stripe.com/queries/stripe/bd6db68c

```sql
SELECT created_at, domain, outcome, tags, step, freeform_context, consumer_account_id, livemode
FROM icecube.eventbus_events.agent_observability_reports_raw
WHERE consumer_account_id = 'acct_1TVyy4RoPKoROpAE'
  AND date_hour >= '2026061620'
ORDER BY created_at DESC
```

(Note: `date_hour` is the archival hour and can lag the event time by an hour, so filter with `>=` rather than an exact hour.)

-- Written by Claude
