### PR TITLE
[Link Agent Wallet] Add reporting instructions to SKILL.md and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ link-cli mpp decode \
 
 ### Report outcomes
 
-Use `report` to record the outcome of a purchase attempt. Call this after every attempt — success or failure — so Stripe can build an agent checkout benchmark.
+Use `report` to record the outcome of a purchase attempt. Reporting is optional, but calling it after attempts — success or failure — helps Stripe build an agent checkout benchmark.
 
 ```bash
 # Successful purchase

--- a/README.md
+++ b/README.md
@@ -267,6 +267,25 @@ link-cli mpp decode \
   --challenge 'Payment id="ch_001", realm="merchant.example", method="stripe", intent="charge", request="..."'
 ```
 
+### Report outcomes
+
+Use `report` to record the outcome of a purchase attempt. Call this after every attempt — success or failure — so Stripe can build an agent checkout benchmark.
+
+```bash
+# Successful purchase
+link-cli report --domain shop.example.com --outcome success --spend-request-id lsrq_abc123
+
+# Blocked by captcha
+link-cli report --domain shop.example.com --outcome blocked --spend-request-id lsrq_abc123 \
+  --tag captcha --step "checkout page" --freeform-context "Turnstile challenge appeared"
+
+# Abandoned due to timeout
+link-cli report --domain shop.example.com --outcome abandoned --spend-request-id lsrq_abc123 \
+  --tag timeout
+```
+
+Outcomes: `success`, `blocked`, `abandoned`. Tags: `stripe_checkout`, `captcha`, `anti_bot_script`, `cdn_block`, `waf_block`, `dns_block`, `rate_limited`, `login_required`, `3ds_challenge`, `page_inaccessible`, `timeout`, `site_error`, `payment_declined`, `other`.
+
 ### Environment variables
 
 | Variable | Effect |

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ link-cli mpp decode \
 
 ### Report outcomes
 
-Use `report` to record the outcome of a purchase attempt. Reporting is optional, but calling it after attempts — success or failure — helps Stripe build an agent checkout benchmark.
+Use `report` to record the outcome of a purchase attempt. Reporting is optional, but calling it after attempts — success or failure — helps Stripe improve checkout for agents.
 
 ```bash
 # Successful purchase

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -234,7 +234,7 @@ All errors are output as JSON with `code` and `message` fields, with exit code 1
 
 ## Reporting outcomes
 
-**REQUIRED:** After every purchase attempt, report the outcome. This applies whether the purchase succeeded, was blocked, or was abandoned.
+After a purchase attempt, you're encouraged to report the outcome — whether it succeeded, was blocked, or was abandoned. This is optional but helps Stripe improve agent checkout.
 
 ```bash
 link-cli report \
@@ -254,7 +254,7 @@ link-cli report \
 
 ### Tags
 
-Add one or more `--tag` flags to classify what happened:
+Add one or more `--tag` flags to classify what happened. Prefer the most specific tag; use `other` only when none of the others apply, and describe what happened in `--freeform-context`.
 
 | Tag | Meaning |
 |---|---|
@@ -286,7 +286,7 @@ link-cli report --domain shop.example.com --outcome blocked --spend-request-id l
 link-cli report --domain shop.example.com --outcome abandoned --spend-request-id lsrq_abc123 --tag site_error --freeform-context "500 error on payment submission"
 ```
 
-Report output is agent-only (not shown to the user). Always report, even if the purchase failed.
+Report output is agent-only (not shown to the user). Reporting is encouraged but not required, including when the purchase failed.
 
 ## Further docs
 

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -232,6 +232,62 @@ All errors are output as JSON with `code` and `message` fields, with exit code 1
 | Spend request approved but payment fails immediately | Wrong credential type for the merchant (e.g. `card` on a 402-only endpoint) | Go back to Step 2, re-evaluate the merchant, create a new spend request with the correct `credential_type` |
 | Auth token expired mid-session (exit code 1 during approval polling) | Token refresh failure during background polling | Re-authenticate with `auth login`, then retrieve the existing spend request or resume polling. Only create a new spend request if the original one expired, was denied, was canceled, or its shared payment token was already consumed |
 
+## Reporting outcomes
+
+**REQUIRED:** After every purchase attempt, report the outcome. This applies whether the purchase succeeded, was blocked, or was abandoned.
+
+```bash
+link-cli report \
+  --domain <merchant-domain> \
+  --outcome <success|blocked|abandoned> \
+  --spend-request-id <lsrq_...> \
+  [--tag <tag>] \
+  [--step <step>] \
+  [--freeform-context "<details>"]
+```
+
+### When to report
+
+- **success** -- payment completed and order confirmed
+- **blocked** -- the agent could not complete payment due to an obstacle (captcha, WAF, rate limit, etc.)
+- **abandoned** -- the agent chose to stop (user canceled, site error, timeout, etc.)
+
+### Tags
+
+Add one or more `--tag` flags to classify what happened:
+
+| Tag | Meaning |
+|---|---|
+| `stripe_checkout` | Merchant uses Stripe checkout |
+| `captcha` | Blocked by CAPTCHA |
+| `anti_bot_script` | Blocked by bot detection script |
+| `cdn_block` | Blocked by CDN (Cloudflare, etc.) |
+| `waf_block` | Blocked by WAF |
+| `dns_block` | DNS-level block |
+| `rate_limited` | Rate limited |
+| `login_required` | Login wall prevented checkout |
+| `3ds_challenge` | 3DS challenge could not be completed |
+| `page_inaccessible` | Page returned error or could not load |
+| `timeout` | Operation timed out |
+| `site_error` | Merchant site returned an error |
+| `payment_declined` | Payment was declined by processor |
+| `other` | Other (describe in freeform-context) |
+
+### Examples
+
+```bash
+# Successful purchase
+link-cli report --domain shop.example.com --outcome success --spend-request-id lsrq_abc123
+
+# Blocked by captcha
+link-cli report --domain shop.example.com --outcome blocked --spend-request-id lsrq_abc123 --tag captcha --step "checkout page"
+
+# Abandoned due to site error
+link-cli report --domain shop.example.com --outcome abandoned --spend-request-id lsrq_abc123 --tag site_error --freeform-context "500 error on payment submission"
+```
+
+Report output is agent-only (not shown to the user). Always report, even if the purchase failed.
+
 ## Further docs
 
 - MPP/x402 protocol: https://mpp.dev/protocol.md, https://mpp.dev/protocol/http-402.md, https://mpp.dev/protocol/challenges.md

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -234,7 +234,7 @@ All errors are output as JSON with `code` and `message` fields, with exit code 1
 
 ## Reporting outcomes
 
-After a purchase attempt, you're encouraged to report the outcome — whether it succeeded, was blocked, or was abandoned. This is optional but helps Stripe improve agent checkout.
+After a purchase attempt, you're encouraged to report the outcome — whether it succeeded, was blocked, or was abandoned. This is optional but helps Stripe improve checkout for agents.
 
 ```bash
 link-cli report \


### PR DESCRIPTION
## Summary

Adds documentation for the `link-cli report` command:

- **SKILL.md**: Reporting instructions for agents — when to report, tag reference table, example commands
- **README.md**: "Report outcomes" section with usage examples

## Dependencies

Requires the CLI command PR: https://github.com/stripe/link-cli/pull/149

## Test plan

- [x] Verify agents follow the reporting instructions when using the skill

-- Written by Claude