### PR TITLE
feat: --approve flag for calling delegated endpoint

### DIFF
--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -147,6 +147,7 @@ export function createSpendRequestCli(
         totals: totals as Total[] | undefined,
         request_approval: requestApproval || undefined,
         test: opts.test ? true : undefined,
+        approve: opts.approve ? true : undefined,
       };
 
       const outputFile = opts.outputFile;

--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -61,6 +61,7 @@ export const createOptions = z.object({
     .describe(
       'Use test mode (creates testmode credentials from test card data)',
     ),
+  approve: z.boolean().default(false).describe(''),
   outputFile: z
     .string()
     .optional()

--- a/packages/sdk/src/resources/__tests__/spend-request.test.ts
+++ b/packages/sdk/src/resources/__tests__/spend-request.test.ts
@@ -141,6 +141,26 @@ describe('SpendRequestResource', () => {
       expect(sentBody.test).toBeUndefined();
     });
 
+    it('sends to /spend_requests/create_delegated when approve is true', async () => {
+      mockFetchResponse(200, spendRequestResponse);
+
+      await repo.createSpendRequest({ ...validParams, approve: true });
+
+      const [url, opts] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://api.link.com/spend_requests/create_delegated');
+      const sentBody = JSON.parse(opts.body);
+      expect(sentBody.approve).toBeUndefined();
+    });
+
+    it('sends to /spend_requests when approve is not set', async () => {
+      mockFetchResponse(200, spendRequestResponse);
+
+      await repo.createSpendRequest(validParams);
+
+      const [url] = mockFetch.mock.calls[0];
+      expect(url).toBe('https://api.link.com/spend_requests');
+    });
+
     it('throws when no access token is available', async () => {
       getAccessToken.mockRejectedValueOnce(new Error('Missing access token'));
 

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -40,6 +40,7 @@ export interface CreateSpendRequestParams {
   totals?: Total[];
   request_approval?: boolean;
   test?: boolean;
+  approve?: boolean;
 }
 
 export interface UpdateSpendRequestParams {

--- a/packages/sdk/src/resources/spend-request.ts
+++ b/packages/sdk/src/resources/spend-request.ts
@@ -172,11 +172,15 @@ export class SpendRequestResource implements ISpendRequestResource {
   async createSpendRequest(
     params: CreateSpendRequestParams,
   ): Promise<SpendRequest> {
+    const { approve, ...body } = params;
+    const url = approve
+      ? `${this.spendRequestsEndpoint}/create_delegated`
+      : this.spendRequestsEndpoint;
     const { status, data, rawBody } = await this.apiFetch({
       method: 'POST',
-      url: this.spendRequestsEndpoint,
+      url,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params),
+      body: JSON.stringify(body),
     });
 
     if (status < 200 || status >= 300) {


### PR DESCRIPTION
Regular creation works as expected:
<img width="1298" height="63" alt="Screenshot 2026-06-12 at 11 31 18 AM" src="https://github.com/user-attachments/assets/3870ef36-607d-41df-b52b-843385a8354a" />

--approve flag (rightfully returns 401 for current connection): 
<img width="1298" height="104" alt="Screenshot 2026-06-12 at 11 30 51 AM" src="https://github.com/user-attachments/assets/dd00a67a-0c47-477a-9476-d193e9fea1cb" />
