### PR TITLE
Add link_pay_token field to SpendRequest type

### DIFF
--- a/packages/cli/src/commands/spend-request/retrieve.tsx
+++ b/packages/cli/src/commands/spend-request/retrieve.tsx
@@ -348,6 +348,15 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
             {request?.line_items.map((li) => li.name).join(', ')}
           </Text>
         </Text>
+        {request?.link_pay_token && (
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold>Link Pay Token:</Text>
+            <Text>
+              {' '}
+              <Text bold>{request.link_pay_token}</Text>
+            </Text>
+          </Box>
+        )}
         {request?.payment_status_details && (
           <Box flexDirection="column" marginTop={1}>
             <Text bold>Last Payment Attempt:</Text>

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -107,6 +107,7 @@ export interface SpendRequest {
   approval_url?: string;
   card?: Card;
   shared_payment_token?: SharedPaymentToken;
+  link_pay_token?: string;
   payment_status_details?: PaymentStatusDetails | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary

- Adds `link_pay_token` as an optional string field on the `SpendRequest` interface in the SDK types

## Context

The Link wallet API returns a `link_pay_token` on approved spend requests when the consumer has authorized a payment. This field was missing from the TypeScript type definition, so it wasn't surfaced in typed SDK consumers. 

## Test plan

- [x] `pnpm run typecheck` passes
- [ ] Verify `link_pay_token` appears in JSON output when retrieving an approved livemode spend request
