### PR TITLE
Skip re-auth if a usable session already exists

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -972,8 +972,12 @@ describe('production mode', () => {
       const output = parseJson(result.stdout) as Record<string, unknown>[];
       expect(output[0].authenticated).toBe(true);
       expect(output[0].message).toMatch(/already logged in/i);
-      expect(requests.find((r) => r.url.includes('/device/code'))).toBeUndefined();
-      expect(requests.find((r) => r.url.includes('/device/revoke'))).toBeUndefined();
+      expect(
+        requests.find((r) => r.url.includes('/device/code')),
+      ).toBeUndefined();
+      expect(
+        requests.find((r) => r.url.includes('/device/revoke')),
+      ).toBeUndefined();
     });
 
     it('sends client_hint and returns immediately with _next polling hint', async () => {

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -952,7 +952,32 @@ describe('production mode', () => {
       expect(output).toMatch(/client.?name|non-empty/i);
     });
 
+    it('exits early with already logged in message when valid session exists', async () => {
+      setResponseForUrl('/device/token', 200, {
+        access_token: 'refreshed_access_token',
+        refresh_token: 'refreshed_refresh_token',
+        expires_in: 3600,
+        token_type: 'Bearer',
+      });
+
+      const result = await runProdCli(
+        'auth',
+        'login',
+        '--client-name',
+        'My Agent',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      const output = parseJson(result.stdout) as Record<string, unknown>[];
+      expect(output[0].authenticated).toBe(true);
+      expect(output[0].message).toMatch(/already logged in/i);
+      expect(requests.find((r) => r.url.includes('/device/code'))).toBeUndefined();
+      expect(requests.find((r) => r.url.includes('/device/revoke'))).toBeUndefined();
+    });
+
     it('sends client_hint and returns immediately with _next polling hint', async () => {
+      setResponseForUrl('/device/token', 401, { error: 'invalid_grant' });
       setResponseForUrl('/device/code', 200, DEVICE_CODE_RESPONSE);
 
       const result = await runProdCli(
@@ -984,7 +1009,8 @@ describe('production mode', () => {
       expect(next.until).toContain('authenticated');
     });
 
-    it('revokes existing session before starting new login', async () => {
+    it('revokes existing session before starting new login when refresh fails', async () => {
+      setResponseForUrl('/device/token', 401, { error: 'invalid_grant' });
       setResponseForUrl('/device/revoke', 200, 'ok');
       setResponseForUrl('/device/code', 200, DEVICE_CODE_RESPONSE);
 
@@ -1007,6 +1033,7 @@ describe('production mode', () => {
     });
 
     it('proceeds with login even if revoke fails', async () => {
+      setResponseForUrl('/device/token', 401, { error: 'invalid_grant' });
       setResponseForUrl('/device/revoke', 500, { error: 'server_error' });
       setResponseForUrl('/device/code', 200, DEVICE_CODE_RESPONSE);
 

--- a/packages/cli/src/commands/auth/index.tsx
+++ b/packages/cli/src/commands/auth/index.tsx
@@ -1,5 +1,6 @@
 import { type AuthStorage, storage as defaultStorage } from '@stripe/link-sdk';
 import { Cli } from 'incur';
+import { Text } from 'ink';
 import React from 'react';
 import type { IAuthResource } from '../../auth/types';
 import { pollUntil } from '../../utils/poll-until';
@@ -111,6 +112,31 @@ export function createAuthCli(
           code: 'INVALID_INPUT',
           message: 'client-name must be a non-empty string',
         });
+      }
+
+      const existingAuth = storage.getAuth();
+      if (existingAuth?.refresh_token) {
+        try {
+          const refreshed = await authResource.refreshToken(existingAuth.refresh_token);
+          storage.setAuth(refreshed);
+          const alreadyLoggedIn = sanitizeDeep({
+            authenticated: true,
+            message:
+              'You are already logged in. To switch accounts, run `link-cli auth logout` first.',
+          });
+          if (!c.agent && !c.formatExplicit) {
+            return renderInteractive(
+              <Text color="yellow">
+                You are already logged in. To switch accounts, run `link-cli auth logout` first.
+              </Text>,
+              () => alreadyLoggedIn,
+            );
+          }
+          yield alreadyLoggedIn;
+          return;
+        } catch {
+          // Session not usable — fall through to full re-auth below
+        }
       }
 
       await maybeRevokeAndClearAuth(authResource, storage);

--- a/packages/cli/src/commands/auth/index.tsx
+++ b/packages/cli/src/commands/auth/index.tsx
@@ -117,7 +117,9 @@ export function createAuthCli(
       const existingAuth = storage.getAuth();
       if (existingAuth?.refresh_token) {
         try {
-          const refreshed = await authResource.refreshToken(existingAuth.refresh_token);
+          const refreshed = await authResource.refreshToken(
+            existingAuth.refresh_token,
+          );
           storage.setAuth(refreshed);
           const alreadyLoggedIn = sanitizeDeep({
             authenticated: true,
@@ -127,7 +129,9 @@ export function createAuthCli(
           if (!c.agent && !c.formatExplicit) {
             return renderInteractive(
               <Text color="yellow">
-                You are already logged in. To switch accounts, run `link-cli auth logout` first.
+                {
+                  'You are already logged in. To switch accounts, run `link-cli auth logout` first.'
+                }
               </Text>,
               () => alreadyLoggedIn,
             );

--- a/packages/cli/src/commands/auth/index.tsx
+++ b/packages/cli/src/commands/auth/index.tsx
@@ -121,18 +121,15 @@ export function createAuthCli(
             existingAuth.refresh_token,
           );
           storage.setAuth(refreshed);
+          const alreadyLoggedInMessage =
+            'You are already logged in. To switch accounts, run `link-cli auth logout` first.';
           const alreadyLoggedIn = sanitizeDeep({
             authenticated: true,
-            message:
-              'You are already logged in. To switch accounts, run `link-cli auth logout` first.',
+            message: alreadyLoggedInMessage,
           });
           if (!c.agent && !c.formatExplicit) {
             return renderInteractive(
-              <Text color="yellow">
-                {
-                  'You are already logged in. To switch accounts, run `link-cli auth logout` first.'
-                }
-              </Text>,
+              <Text color="yellow">{alreadyLoggedInMessage}</Text>,
               () => alreadyLoggedIn,
             );
           }


### PR DESCRIPTION
## Summary
  - `auth login` now checks for an existing valid session before proceeding
  - If a refresh token exists and can be refreshed, exits early with a yellow "You are already logged in" message — no revocation, no device auth flow, no disconnection email
  - If the refresh fails, falls through to the existing `maybeRevokeAndClearAuth` + device auth flow as before
## Motivation
Previously, `auth login` unconditionally revoked the existing session and kicked off a new device auth flow, even when the user was already authenticated. This sent a "you disconnected from link-cli" email and invalidated a good session

<img width="676" height="114" alt="Screenshot 2026-06-17 at 11 06 43 AM" src="https://github.com/user-attachments/assets/9801d859-b716-4472-8c6d-1ab3131f40fe" />
