### PR TITLE
surface user eligibility in auth login and payment-methods list

### DIFF
--- a/packages/cli/src/auth/auth-resource.ts
+++ b/packages/cli/src/auth/auth-resource.ts
@@ -1,5 +1,10 @@
 import { hostname } from 'node:os';
-import { LinkApiError, LinkTransportError } from '@stripe/link-sdk';
+import {
+  LinkApiError,
+  LinkAuthorizationDeclinedError,
+  LinkTransportError,
+  type ScopeEligibility,
+} from '@stripe/link-sdk';
 import {
   type AuthResourceOptions,
   type ResolvedAuthResourceConfig,
@@ -30,6 +35,7 @@ interface TokenResponse {
 interface OAuthError {
   error: string;
   error_description?: string;
+  scope_eligibility?: Record<string, ScopeEligibility>;
 }
 
 function formatOAuthError(
@@ -173,6 +179,8 @@ export class LinkAuthResource implements IAuthResource {
             rawBody,
             details: data,
           });
+        case 'authorization_failed':
+          throw new LinkAuthorizationDeclinedError(err.scope_eligibility ?? {});
       }
     }
 

--- a/packages/cli/src/commands/auth/login.tsx
+++ b/packages/cli/src/commands/auth/login.tsx
@@ -1,4 +1,9 @@
-import { type AuthStorage, storage as defaultStorage } from '@stripe/link-sdk';
+import {
+  type AuthStorage,
+  LinkAuthorizationDeclinedError,
+  type ScopeEligibility,
+  storage as defaultStorage,
+} from '@stripe/link-sdk';
 import { Box, Text, useInput } from 'ink';
 import Spinner from 'ink-spinner';
 import type React from 'react';
@@ -22,12 +27,13 @@ export const Login: React.FC<LoginProps> = ({
 }) => {
   const storage = authStorage;
   const [status, setStatus] = useState<
-    'initiating' | 'waiting' | 'polling' | 'success' | 'error'
+    'initiating' | 'waiting' | 'polling' | 'success' | 'error' | 'declined'
   >('initiating');
   const [userCode, setUserCode] = useState<string>('');
   const [verificationUrl, setVerificationUrl] = useState<string>('');
   const [deviceCode, setDeviceCode] = useState<string>('');
   const [error, setError] = useState<string>('');
+  const [scopeEligibility, setScopeEligibility] = useState<Record<string, ScopeEligibility>>({});
 
   const isActive = status === 'waiting' || status === 'polling';
 
@@ -73,8 +79,13 @@ export const Login: React.FC<LoginProps> = ({
           }
         } catch (err) {
           clearInterval(pollInterval);
-          setError((err as Error).message);
-          setStatus('error');
+          if (err instanceof LinkAuthorizationDeclinedError) {
+            setScopeEligibility(err.scopeEligibility);
+            setStatus('declined');
+          } else {
+            setError((err as Error).message);
+            setStatus('error');
+          }
         }
       }, 2000);
 
@@ -93,6 +104,28 @@ export const Login: React.FC<LoginProps> = ({
         <Text color="cyan">
           <Spinner type="dots" /> Initiating authentication...
         </Text>
+      </Box>
+    );
+  }
+
+  if (status === 'declined') {
+    return (
+      <Box flexDirection="column">
+        <Text color="red">✗ Authorization failed</Text>
+        {Object.entries(scopeEligibility).map(([scope, info]) => (
+          <Box key={scope} flexDirection="column" marginLeft={2}>
+            <Text>
+              <Text dimColor>{scope}:</Text>
+              {' ineligible'}
+              {info.ineligibility_reasons.length > 0
+                ? ` (${info.ineligibility_reasons.join(', ')})`
+                : ''}
+            </Text>
+            {info.description ? (
+              <Text dimColor>{info.description}</Text>
+            ) : null}
+          </Box>
+        ))}
       </Box>
     );
   }

--- a/packages/cli/src/commands/auth/login.tsx
+++ b/packages/cli/src/commands/auth/login.tsx
@@ -33,7 +33,9 @@ export const Login: React.FC<LoginProps> = ({
   const [verificationUrl, setVerificationUrl] = useState<string>('');
   const [deviceCode, setDeviceCode] = useState<string>('');
   const [error, setError] = useState<string>('');
-  const [scopeEligibility, setScopeEligibility] = useState<Record<string, ScopeEligibility>>({});
+  const [scopeEligibility, setScopeEligibility] = useState<
+    Record<string, ScopeEligibility>
+  >({});
 
   const isActive = status === 'waiting' || status === 'polling';
 
@@ -121,9 +123,7 @@ export const Login: React.FC<LoginProps> = ({
                 ? ` (${info.ineligibility_reasons.join(', ')})`
                 : ''}
             </Text>
-            {info.description ? (
-              <Text dimColor>{info.description}</Text>
-            ) : null}
+            {info.description ? <Text dimColor>{info.description}</Text> : null}
           </Box>
         ))}
       </Box>

--- a/packages/cli/src/commands/payment-methods/list.tsx
+++ b/packages/cli/src/commands/payment-methods/list.tsx
@@ -56,6 +56,8 @@ export const PaymentMethodsList: React.FC<PaymentMethodsListProps> = ({
           const last4 =
             pm.card_details?.last4 ?? pm.bank_account_details?.last4;
           const suffix = pm.nickname ? `(${pm.nickname})` : '';
+          const agenticCap = pm.capabilities?.agentic_payments;
+          const ineligible = agenticCap && !agenticCap.eligible;
           return (
             <Box key={pm.id} paddingX={2}>
               <Text>
@@ -64,6 +66,14 @@ export const PaymentMethodsList: React.FC<PaymentMethodsListProps> = ({
                 {label} ****{last4}
                 {suffix ? ` ${suffix}` : ''}
                 {pm.is_default ? <Text color="green"> (default)</Text> : ''}
+                {ineligible ? (
+                  <Text dimColor>
+                    {'  '}agentic_payments: ineligible
+                    {agenticCap.ineligibility_reasons?.length > 0
+                      ? ` (${agenticCap.ineligibility_reasons.join(', ')})`
+                      : ''}
+                  </Text>
+                ) : null}
               </Text>
             </Box>
           );

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -38,9 +38,12 @@ export class LinkAuthorizationDeclinedError extends LinkSdkError {
   readonly scopeEligibility: Record<string, ScopeEligibility>;
 
   constructor(scopeEligibility: Record<string, ScopeEligibility>) {
-    super('Authorization declined: account is not eligible for requested scopes', {
-      code: 'authorization_declined',
-    });
+    super(
+      'Authorization declined: account is not eligible for requested scopes',
+      {
+        code: 'authorization_declined',
+      },
+    );
     this.scopeEligibility = scopeEligibility;
   }
 }

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -28,6 +28,23 @@ export class LinkTransportError extends LinkSdkError {
   }
 }
 
+export interface ScopeEligibility {
+  eligible: boolean;
+  ineligibility_reasons: string[];
+  description?: string;
+}
+
+export class LinkAuthorizationDeclinedError extends LinkSdkError {
+  readonly scopeEligibility: Record<string, ScopeEligibility>;
+
+  constructor(scopeEligibility: Record<string, ScopeEligibility>) {
+    super('Authorization declined: account is not eligible for requested scopes', {
+      code: 'authorization_declined',
+    });
+    this.scopeEligibility = scopeEligibility;
+  }
+}
+
 export class LinkApiError extends LinkSdkError {
   readonly status: number;
   readonly rawBody?: string;

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -138,6 +138,11 @@ export interface UserInfo {
   phone?: string | null;
 }
 
+export interface ProductCapability {
+  eligible: boolean;
+  ineligibility_reasons: string[];
+}
+
 export interface PaymentMethod {
   id: string;
   type: string;
@@ -145,6 +150,7 @@ export interface PaymentMethod {
   nickname?: string;
   card_details?: CardDetails;
   bank_account_details?: BankAccountDetails;
+  capabilities?: Record<string, ProductCapability>;
 }
 
 export interface ShippingAddress {


### PR DESCRIPTION
Previously when a user who is ineligible for link-cli attempted to log in, the CLI would hang waiting on "Waiting for authorization..." and the authorization_failed error from the token poll endpoint was unhandled and fell through to a generic error that gave no useful signal on why they are ineligible. Similarly, we don't have a surface to show users why they couldn't make payments or why certain payment methods they added are ineligible. In this PR, we surface user eligibility in auth login and payment-methods list so users understand why they are ineligible.

- sdk/src/errors.ts — new LinkAuthorizationDeclinedError class (code: authorization_declined) carrying a scopeEligibility map, and a ScopeEligibility interface (eligible, ineligibility_reasons, description)
- sdk/src/types/index.ts — new ProductCapability interface; added capabilities?: Record<string, ProductCapability> to PaymentMethod to surface per-payment-method eligibility from the API
- cli/src/auth/auth-resource.ts — handles authorization_failed in the pollDeviceAuth switch, throwing LinkAuthorizationDeclinedError with the scope_eligibility payload from the response instead of falling through to a generic error
- cli/src/commands/auth/login.tsx — adds a declined status with structured rendering: shows ✗ Authorization failed with per-scope ineligibility reasons and description
- cli/src/commands/payment-methods/list.tsx — annotates ineligible payment methods inline: agentic_payments: ineligible (non_us_payment_method) (only shown when the capabilities field is present in the API response, gated by feature flag)

<img width="999" height="119" alt="Screenshot 2026-06-18 at 2 02 19 PM" src="https://github.com/user-attachments/assets/4c49d8c8-de45-437e-a0d5-675d92025de2" />