### PR TITLE
Add --include-history flag to surface all spend request history in spend request list

### DIFF
--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -21,7 +21,12 @@ import { CreateSpendRequest } from './create';
 import { SpendRequestList } from './list';
 import { RequestApproval } from './request-approval';
 import { RetrieveSpendRequest } from './retrieve';
-import { createOptions, listOptions, retrieveOptions, updateOptions } from './schema';
+import {
+  createOptions,
+  listOptions,
+  retrieveOptions,
+  updateOptions,
+} from './schema';
 import { UpdateSpendRequest } from './update';
 
 async function applyOutputFile(
@@ -67,7 +72,11 @@ export function createSpendRequestCli(
 
       if (!c.agent && !c.formatExplicit) {
         return renderInteractive(
-          <SpendRequestList repository={repository} includeHistory={opts.includeHistory} onComplete={() => {}} />,
+          <SpendRequestList
+            repository={repository}
+            includeHistory={opts.includeHistory}
+            onComplete={() => {}}
+          />,
           () => repository.listSpendRequests(opts),
         );
       }

--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -21,7 +21,7 @@ import { CreateSpendRequest } from './create';
 import { SpendRequestList } from './list';
 import { RequestApproval } from './request-approval';
 import { RetrieveSpendRequest } from './retrieve';
-import { createOptions, retrieveOptions, updateOptions } from './schema';
+import { createOptions, listOptions, retrieveOptions, updateOptions } from './schema';
 import { UpdateSpendRequest } from './update';
 
 async function applyOutputFile(
@@ -58,18 +58,21 @@ export function createSpendRequestCli(
 
   cli.command('list', {
     description:
-      'List active spend requests (created, pending_approval, approved)',
+      'List spend requests. By default returns only active requests (created, pending_approval, approved). Use --include-history to return all spend requests including expired and terminal states.',
     outputPolicy: 'agent-only' as const,
+    options: listOptions,
     middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {
+      const opts = { includeHistory: c.options.includeHistory ?? false };
+
       if (!c.agent && !c.formatExplicit) {
         return renderInteractive(
-          <SpendRequestList repository={repository} onComplete={() => {}} />,
-          () => repository.listSpendRequests(),
+          <SpendRequestList repository={repository} includeHistory={opts.includeHistory} onComplete={() => {}} />,
+          () => repository.listSpendRequests(opts),
         );
       }
 
-      return repository.listSpendRequests();
+      return repository.listSpendRequests(opts);
     },
   });
 

--- a/packages/cli/src/commands/spend-request/list.tsx
+++ b/packages/cli/src/commands/spend-request/list.tsx
@@ -7,17 +7,19 @@ import { useAsyncAction } from '../../hooks/use-async-action';
 
 interface SpendRequestListProps {
   repository: ISpendRequestResource;
+  includeHistory?: boolean;
   onComplete: (result: SpendRequest[] | null) => void;
 }
 
 export const SpendRequestList: React.FC<SpendRequestListProps> = ({
   repository,
+  includeHistory = false,
   onComplete,
 }) => {
   const { exit } = useApp();
   const action = useCallback(
-    () => repository.listSpendRequests(),
-    [repository],
+    () => repository.listSpendRequests({ includeHistory }),
+    [repository, includeHistory],
   );
   const wrappedOnComplete = useCallback(
     (result: SpendRequest[] | null) => {
@@ -54,7 +56,7 @@ export const SpendRequestList: React.FC<SpendRequestListProps> = ({
   if (!requests || requests.length === 0) {
     return (
       <Box>
-        <Text dimColor>No active spend requests found</Text>
+        <Text dimColor>No spend requests found</Text>
       </Box>
     );
   }

--- a/packages/cli/src/commands/spend-request/list.tsx
+++ b/packages/cli/src/commands/spend-request/list.tsx
@@ -67,7 +67,9 @@ export const SpendRequestList: React.FC<SpendRequestListProps> = ({
 
   return (
     <Box flexDirection="column">
-      <Text bold>Active Spend Requests</Text>
+      <Text bold>
+        {includeHistory ? 'All Spend Requests' : 'Active Spend Requests'}
+      </Text>
       <Box flexDirection="column" marginTop={1}>
         {requests.map((sr) => {
           const statusColor =

--- a/packages/cli/src/commands/spend-request/list.tsx
+++ b/packages/cli/src/commands/spend-request/list.tsx
@@ -56,7 +56,11 @@ export const SpendRequestList: React.FC<SpendRequestListProps> = ({
   if (!requests || requests.length === 0) {
     return (
       <Box>
-        <Text dimColor>No spend requests found</Text>
+        <Text dimColor>
+          {includeHistory
+            ? 'No spend requests found'
+            : 'No active spend requests found'}
+        </Text>
       </Box>
     );
   }

--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -74,6 +74,13 @@ export const createOptions = z.object({
     .describe('Overwrite output file if it already exists'),
 });
 
+export const listOptions = z.object({
+  includeHistory: z
+    .boolean()
+    .default(false)
+    .describe('Include expired and terminal spend requests'),
+});
+
 export const retrieveOptions = z.object({
   timeout: z.coerce
     .number()

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -55,8 +55,8 @@ export interface UpdateSpendRequestParams {
 }
 
 export interface ISpendRequestResource {
-  list(): Promise<SpendRequest[]>;
-  listSpendRequests(): Promise<SpendRequest[]>;
+  list(opts?: { includeHistory?: boolean }): Promise<SpendRequest[]>;
+  listSpendRequests(opts?: { includeHistory?: boolean }): Promise<SpendRequest[]>;
   create(params: CreateSpendRequestParams): Promise<SpendRequest>;
   createSpendRequest(params: CreateSpendRequestParams): Promise<SpendRequest>;
   update(id: string, params: UpdateSpendRequestParams): Promise<SpendRequest>;

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -56,7 +56,9 @@ export interface UpdateSpendRequestParams {
 
 export interface ISpendRequestResource {
   list(opts?: { includeHistory?: boolean }): Promise<SpendRequest[]>;
-  listSpendRequests(opts?: { includeHistory?: boolean }): Promise<SpendRequest[]>;
+  listSpendRequests(opts?: { includeHistory?: boolean }): Promise<
+    SpendRequest[]
+  >;
   create(params: CreateSpendRequestParams): Promise<SpendRequest>;
   createSpendRequest(params: CreateSpendRequestParams): Promise<SpendRequest>;
   update(id: string, params: UpdateSpendRequestParams): Promise<SpendRequest>;

--- a/packages/sdk/src/resources/spend-request.ts
+++ b/packages/sdk/src/resources/spend-request.ts
@@ -143,14 +143,18 @@ export class SpendRequestResource implements ISpendRequestResource {
     return res;
   }
 
-  list(): Promise<SpendRequest[]> {
-    return this.listSpendRequests();
+  list(opts?: { includeHistory?: boolean }): Promise<SpendRequest[]> {
+    return this.listSpendRequests(opts);
   }
 
-  async listSpendRequests(): Promise<SpendRequest[]> {
+  async listSpendRequests(opts?: { includeHistory?: boolean }): Promise<SpendRequest[]> {
+    const url = opts?.includeHistory
+      ? `${this.spendRequestsEndpoint}?include_history=true`
+      : this.spendRequestsEndpoint;
+
     const { status, data, rawBody } = await this.apiFetch({
       method: 'GET',
-      url: this.spendRequestsEndpoint,
+      url,
     });
 
     if (status < 200 || status >= 300) {

--- a/packages/sdk/src/resources/spend-request.ts
+++ b/packages/sdk/src/resources/spend-request.ts
@@ -147,7 +147,9 @@ export class SpendRequestResource implements ISpendRequestResource {
     return this.listSpendRequests(opts);
   }
 
-  async listSpendRequests(opts?: { includeHistory?: boolean }): Promise<SpendRequest[]> {
+  async listSpendRequests(opts?: { includeHistory?: boolean }): Promise<
+    SpendRequest[]
+  > {
     const url = opts?.includeHistory
       ? `${this.spendRequestsEndpoint}?include_history=true`
       : this.spendRequestsEndpoint;


### PR DESCRIPTION
**Summary**
- Adds --include-history flag to spend-request list that appends ?include_history=true to the API request, returning expired and terminal spend requests in addition to active ones
- By default, list continues to return only active requests (created, pending_approval, approved)
- Updates the empty state message from "No active spend requests found" → "No spend requests found" to be accurate when history is included

**Changes**

  - packages/sdk/src/resources/interfaces.ts: added opts?: { includeHistory?: boolean } to list/listSpendRequests signatures
  - packages/sdk/src/resources/spend-request.ts: conditionally appends ?include_history=true query param
  - packages/cli/src/commands/spend-request/schema.ts: new listOptions schema with includeHistory boolean flag
  - packages/cli/src/commands/spend-request/index.tsx: wires --include-history flag through to SDK call and interactive component
  - packages/cli/src/commands/spend-request/list.tsx: accepts and forwards includeHistory prop; updated empty state copy


<img width="860" height="548" alt="Screenshot 2026-06-22 at 5 34 11 PM" src="https://github.com/user-attachments/assets/13067d47-ab19-42af-8f52-faa85b05a3ee" />

