### PR TITLE
v0.8.0 changeset

### DIFF
--- a/.changeset/v0.8.0-features.md
+++ b/.changeset/v0.8.0-features.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": minor
+---
+
+some improvemnts: Add --include-history flag to spend-request list; surface user eligibility in auth login and payment-methods list; add report command for agent observability; skip re-auth when a usable session already exists


### PR DESCRIPTION
some improvements included in this changeset: Add --include-history flag to spend-request list; surface user eligibility in auth login and payment-methods list; add report command for agent observability; skip re-auth when a usable session already exists
