### PR TITLE
Add changeset for report command docs

### DIFF
--- a/.changeset/report-outcome-docs.md
+++ b/.changeset/report-outcome-docs.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": patch
+---
+
+Document the `report` command: add a "Report outcomes" section to the README and reporting guidance to the create-payment-credential skill, covering the outcome types (`success`, `blocked`, `abandoned`) and the tag reference. Reporting is described as optional.


### PR DESCRIPTION
## Summary

Adds a changeset for the report-command documentation that landed in #150.

#150 ("Add reporting instructions to SKILL.md and README") merged after `0.8.0` without a changeset, so it's currently unreleased. The root `README.md` ships in the published npm package (`files` includes `README.md`, and `prepublishOnly` copies it in), and #150 added the "Report outcomes" section to it — so a release is needed to get the updated README onto npm.

This is a docs-only change, so it's a `patch` bump (`0.8.0` → `0.8.1`). The `report` command itself already shipped in `0.8.0`.

## What this does

- Adds `.changeset/report-outcome-docs.md` (`@stripe/link-cli: patch`).
- The next **Version Packages** PR will consume it, bump `packages/cli/package.json` to `0.8.1`, and update `CHANGELOG.md`.

No code changes.

-- Written by Claude
