### PR TITLE
make payment method id optional for spend-request create

### DIFF
--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'incur';
 
 export const createOptions = z.object({
-  paymentMethodId: z.string().describe('Payment method ID'),
+  paymentMethodId: z.string().optional().describe('Payment method ID'),
   credentialType: z
     .enum(['shared_payment_token', 'card'])
     .default('card')

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -28,7 +28,7 @@ export type AccessTokenProvider = (
 ) => Promise<string> | string;
 
 export interface CreateSpendRequestParams {
-  payment_details: string;
+  payment_details?: string;
   credential_type?: CredentialType;
   network_id?: string;
   amount?: number;


### PR DESCRIPTION
 - Makes --payment-method-id optional in spend-request create, allowing the API to use the user's default payment method when none is explicitly provided
 
<img width="1048" height="489" alt="Screenshot 2026-06-24 at 10 18 32 AM" src="https://github.com/user-attachments/assets/b1b81f65-05cf-4a4c-870d-3c6dca7d9454" />
