### PR TITLE
Re-add Link Pay Token flow to create-payment-credential skill

### DIFF
--- a/plugins/link/.claude-plugin/plugin.json
+++ b/plugins/link/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "link",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Authenticate with Link, create spend requests, and retrieve one-time-use card or shared payment token credentials for user-approved purchases.",
   "author": {
     "name": "Stripe"

--- a/plugins/link/.codex-plugin/plugin.json
+++ b/plugins/link/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "link",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Secure, one-time-use payment credentials from Link",
   "author": {
     "name": "Stripe",

--- a/plugins/link/.cursor-plugin/plugin.json
+++ b/plugins/link/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "link",
   "displayName": "Stripe Link",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Get secure, one-time-use payment credentials from a Link wallet so agents can complete purchases on your behalf.",
   "author": {
     "name": "Stripe"

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: 0.7.2
+version: 0.7.3
 name: create-payment-credential
 description: |
   Gets secure, one-time-use payment credentials (cards, tokens) from a Link wallet so agents can complete purchases on behalf of users. Use when the user says "get me a card", "buy something", "pay for X", "make a purchase", "I need to pay", "complete checkout", or asks to transact on any merchant site. Use when the user asks to connect or log in to or sign up for their Link account.
@@ -113,14 +113,16 @@ Always check the current authentication status before starting a new login flow 
 **Determine how the merchant accepts payment:**
 
 1. **Navigate to the merchant page** — browse it, read the page content, and understand how the site accepts payment.
-2. **If the page has a credit card form, Stripe Elements, or traditional checkout UI** — use `card`.
-3. **If the page describes an API or programmatic payment flow** — make a request to the relevant endpoint. If it returns **HTTP 402** with a `www-authenticate` header, use `shared_payment_token`.
+2. **If the checkout page contains a hidden input `input[name="link_pay_token"]`** (typically inside a Stripe iframe) — use the **Link Pay Token flow** (Step 5, "Link Pay Token" section). This is the most seamless path. **Requires browser automation.** If you do not have browser automation available, fall back to the `card` credential flow instead.
+3. **If the page has a credit card form without a hidden `link_pay_token` input** — use `card`.
+4. **If the page describes an API or programmatic payment flow** — make a request to the relevant endpoint. If it returns **HTTP 402** with a `www-authenticate` header, use `shared_payment_token`.
 
 What you find determines which credential type to use:
 
 | What you see | Credential type | What to request |
 |---|---|---|
-| Credit card form / Stripe Elements | `card` (default) | Card |
+| Hidden `input[name="link_pay_token"]` present on page | (none needed) | Link Pay Token flow |
+| Credit card form (no hidden `link_pay_token` input) | `card` (default) | Card |
 | HTTP 402 with `method="stripe"` in `www-authenticate` | `shared_payment_token` | Shared payment token (SPT) |
 | HTTP 402 without `method="stripe"` in `www-authenticate` | not supported | Do not continue |
 
@@ -193,6 +195,39 @@ link-cli mpp pay <url> --spend-request-id <id> [--method POST] [--data '{"amount
 ```
 
 `mpp pay` handles the full 402 flow automatically: probes the URL, parses the `www-authenticate` header, builds the `Authorization: Payment` credential using the SPT, and retries.
+
+**Link Pay Token:** When the checkout page contains a hidden `input[name="link_pay_token"]` (typically inside a Stripe iframe), no card numbers are needed for this transaction. This flow requires browser automation.
+
+1. Create a spend request (same as Step 4 -- no `--credential-type` flag needed) and get approval.
+
+2. Retrieve the Link Pay Token:
+
+   ```bash
+   link-cli spend-request retrieve <id> --include link_pay_token --format json
+   ```
+
+   The response includes `link_pay_token: "eyJ..."`.
+
+3. Open the merchant checkout page in a browser.
+
+4. Find the hidden input `input[name="link_pay_token"]` (it may be inside an iframe) and inject the token using a native input event:
+
+   ```javascript
+   const input = document.querySelector('input[name="link_pay_token"]');
+   Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')
+     .set.call(input, token);
+   input.dispatchEvent(new Event('input', { bubbles: true }));
+   ```
+
+5. Wait for the checkout to transition -- the card form disappears and a saved card appears with the consumer's email in the header. This confirms the token exchange and login succeeded.
+
+6. Click the Pay/Submit button. Payment confirms without CVC or CAPTCHA.
+
+**Important notes for the Link Pay Token flow:**
+- The token is short-lived -- complete the flow promptly after retrieval.
+- In this flow, card numbers are not needed -- the token authorizes payment directly using the consumer's saved card on file.
+- If the browser already has an existing session cookie, the checkout may show a pre-existing session instead of the card form with the hidden input. Use a fresh browser context to ensure the token injection triggers.
+- The consumer only sees the card they authorized in the spend request.
 
 
 ## Important


### PR DESCRIPTION
## Summary

Re-adds the Link Pay Token (LPT) flow to `skills/create-payment-credential/SKILL.md`. Supersedes #163, which was reverted in #166.

## Why #163 was reverted, and why now

#163 was reverted (#166) for two reasons:

- **Timing:** the end-to-end flow wasn't usable yet when #163 merged, so the documented steps couldn't be completed against a live merchant.
- **A bug in the documented command:** the retrieve step omitted `--include link_pay_token`, so following the doc verbatim returned no token.

Both are resolved now. The flow works end to end and has been verified; so re-documenting it is appropriate.

## What's different from #163

- **Fixes the retrieve command:** uses `spend-request retrieve <id> --include link_pay_token`. The token is gated behind `--include link_pay_token`; #163 omitted it, so its documented flow would have returned no token.
- Adds Step 2 detection (hidden `input[name="link_pay_token"]` present => LPT flow; otherwise fall back to `card`) plus a decision table.
- Adds LPT-flow notes: short-lived token, use a fresh browser context, the consumer only sees the card they authorized.

## Safety

The guidance is self-gating. An agent only takes the LPT path when the checkout page actually contains the hidden `input[name="link_pay_token"]`; on any page without it, the skill falls back to the `card` credential flow. A merchant that doesn't surface the token input will never have the agent attempt the token flow.

## Test plan

- Documentation-only change (SKILL.md); no code paths affected.
- [ ] N/A — docs only

## Rollout / revert

- Docs change; safe to revert.
- Keep the `card` fallback prominent (retained).
- Optional follow-up: add a mid-flow fallback so a partially-enabled merchant doesn't strand the agent — if the LPT injection doesn't complete (card doesn't auto-select or the pay button errors), retrieve `--include card` on the same spend request and use the card form. (Verify the same spend request can yield a card before documenting.)
