### PR TITLE
Extract shared HTTP transport layer into BaseResource

### DIFF
--- a/packages/sdk/src/resources/base.ts
+++ b/packages/sdk/src/resources/base.ts
@@ -1,0 +1,147 @@
+import {
+  type LinkOptions,
+  requireFetchImplementation,
+  resolveLinkSdkConfig,
+} from '@/config';
+import { LinkApiError, LinkTransportError } from '@/errors';
+import type { AccessTokenProvider } from '@/resources/interfaces';
+
+export interface ApiFetchOptions {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export interface ApiFetchResult {
+  status: number;
+  data: unknown;
+  rawBody: string;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function requireBoolean(value: unknown, field: string): boolean {
+  if (typeof value !== 'boolean') {
+    throw new TypeError(`Expected ${field} to be a boolean`);
+  }
+  return value;
+}
+
+export function extractErrorMessage(data: unknown, rawBody: string): string {
+  if (isRecord(data)) {
+    if (typeof data.error === 'string') {
+      return data.error;
+    }
+    if (isRecord(data.error)) {
+      const nested = data.error;
+      if (typeof nested.message === 'string') {
+        return nested.message;
+      }
+      if (typeof nested.code === 'string') {
+        return nested.code;
+      }
+    }
+    if (typeof data.message === 'string') {
+      return data.message;
+    }
+  }
+
+  return rawBody || 'unknown error';
+}
+
+export abstract class BaseResource {
+  protected readonly verbose: boolean;
+  protected readonly getAccessToken: AccessTokenProvider;
+  protected readonly fetchImpl: typeof globalThis.fetch;
+  protected readonly endpoint: string;
+  protected readonly logger: { debug(message: string): void };
+
+  constructor(options: LinkOptions, endpointPath: string) {
+    const config = resolveLinkSdkConfig(options);
+    this.verbose = config.verbose;
+    this.getAccessToken = config.getAccessToken;
+    this.fetchImpl = requireFetchImplementation(config);
+    this.endpoint = `${config.apiBaseUrl}${endpointPath}`;
+    this.logger = config.logger;
+  }
+
+  protected async rawFetch(opts: ApiFetchOptions): Promise<ApiFetchResult> {
+    if (this.verbose) {
+      const redactedHeaders = { ...opts.headers };
+      if (redactedHeaders.Authorization)
+        redactedHeaders.Authorization = 'Bearer <redacted>';
+      this.logger.debug(`> ${opts.method} ${opts.url}`);
+      this.logger.debug(`  Headers: ${JSON.stringify(redactedHeaders)}`);
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(opts.url, {
+        method: opts.method,
+        headers: opts.headers,
+      });
+    } catch (error) {
+      throw new LinkTransportError(
+        `Request failed: ${opts.method} ${opts.url}`,
+        { cause: error },
+      );
+    }
+    const rawBody = await response.text();
+
+    let data: unknown = null;
+    try {
+      data = JSON.parse(rawBody);
+    } catch {
+      // non-JSON response (e.g., from load balancer)
+    }
+
+    if (this.verbose) {
+      this.logger.debug(`< ${response.status} ${response.statusText}`);
+      response.headers.forEach((value, key) => {
+        this.logger.debug(`  ${key}: ${value}`);
+      });
+      this.logger.debug(rawBody);
+    }
+
+    return { status: response.status, data, rawBody };
+  }
+
+  protected async apiFetch(opts: ApiFetchOptions): Promise<ApiFetchResult> {
+    const token = await this.getAccessToken();
+    const authedOpts = {
+      ...opts,
+      headers: {
+        ...opts.headers,
+        Authorization: `Bearer ${token}`,
+      },
+    };
+
+    const res = await this.rawFetch(authedOpts);
+
+    if (res.status === 401) {
+      const refreshedToken = await this.getAccessToken({ forceRefresh: true });
+      authedOpts.headers.Authorization = `Bearer ${refreshedToken}`;
+      return this.rawFetch(authedOpts);
+    }
+
+    return res;
+  }
+
+  protected throwApiError(
+    operation: string,
+    status: number,
+    data: unknown,
+    rawBody: string,
+    cause?: unknown,
+  ): never {
+    const msg = extractErrorMessage(data, rawBody);
+    throw new LinkApiError(`Failed to ${operation} (${status}): ${msg}`, {
+      status,
+      rawBody,
+      details: data,
+      cause,
+    });
+  }
+}

--- a/packages/sdk/src/resources/transactions.ts
+++ b/packages/sdk/src/resources/transactions.ts
@@ -1,11 +1,7 @@
-import {
-  type LinkOptions,
-  requireFetchImplementation,
-  resolveLinkSdkConfig,
-} from '@/config';
-import { LinkApiError, LinkTransportError } from '@/errors';
+import type { LinkOptions } from '@/config';
+import { LinkApiError } from '@/errors';
+import { BaseResource, isRecord, requireBoolean } from '@/resources/base';
 import type {
-  AccessTokenProvider,
   ITransactionsResource,
   ListTransactionsParams,
 } from '@/resources/interfaces';
@@ -14,16 +10,6 @@ import type {
   TransactionOrigin,
   TransactionsPage,
 } from '@/types/index';
-
-interface ApiFetchOptions {
-  method: string;
-  url: string;
-  headers?: Record<string, string>;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
 
 function requireString(value: unknown, field: string): string {
   if (typeof value !== 'string') {
@@ -45,13 +31,6 @@ function requireNullableString(value: unknown, field: string): string | null {
 function requireNumber(value: unknown, field: string): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     throw new TypeError(`Expected ${field} to be a finite number`);
-  }
-  return value;
-}
-
-function requireBoolean(value: unknown, field: string): boolean {
-  if (typeof value !== 'boolean') {
-    throw new TypeError(`Expected ${field} to be a boolean`);
   }
   return value;
 }
@@ -126,86 +105,12 @@ function normalizeTransactionsPage(value: unknown): TransactionsPage {
   };
 }
 
-export class TransactionsResource implements ITransactionsResource {
-  private readonly verbose: boolean;
-  private readonly getAccessToken: AccessTokenProvider;
-  private readonly fetchImpl: typeof globalThis.fetch;
-  private readonly endpoint: string;
-  private readonly logger: { debug(message: string): void };
-
+export class TransactionsResource
+  extends BaseResource
+  implements ITransactionsResource
+{
   constructor(options: LinkOptions = {}) {
-    const config = resolveLinkSdkConfig(options);
-    this.verbose = config.verbose;
-    this.getAccessToken = config.getAccessToken;
-    this.fetchImpl = requireFetchImplementation(config);
-    this.endpoint = `${config.apiBaseUrl}/transactions`;
-    this.logger = config.logger;
-  }
-
-  private async rawFetch(
-    opts: ApiFetchOptions,
-  ): Promise<{ status: number; data: unknown; rawBody: string }> {
-    if (this.verbose) {
-      const redactedHeaders = { ...opts.headers };
-      if (redactedHeaders.Authorization)
-        redactedHeaders.Authorization = 'Bearer <redacted>';
-      this.logger.debug(`> ${opts.method} ${opts.url}`);
-      this.logger.debug(`  Headers: ${JSON.stringify(redactedHeaders)}`);
-    }
-
-    let response: Response;
-    try {
-      response = await this.fetchImpl(opts.url, {
-        method: opts.method,
-        headers: opts.headers,
-      });
-    } catch (error) {
-      throw new LinkTransportError(
-        `Request failed: ${opts.method} ${opts.url}`,
-        { cause: error },
-      );
-    }
-    const rawBody = await response.text();
-
-    let data: unknown = null;
-    try {
-      data = JSON.parse(rawBody);
-    } catch {
-      // non-JSON response (e.g., from load balancer)
-    }
-
-    if (this.verbose) {
-      this.logger.debug(`< ${response.status} ${response.statusText}`);
-      response.headers.forEach((value, key) => {
-        this.logger.debug(`  ${key}: ${value}`);
-      });
-      this.logger.debug(rawBody);
-    }
-
-    return { status: response.status, data, rawBody };
-  }
-
-  private async apiFetch(
-    opts: ApiFetchOptions,
-  ): Promise<{ status: number; data: unknown; rawBody: string }> {
-    const token = await this.getAccessToken();
-    const authedOpts = {
-      ...opts,
-      headers: {
-        ...opts.headers,
-        Authorization: `Bearer ${token}`,
-      },
-    };
-
-    const res = await this.rawFetch(authedOpts);
-
-    if (res.status === 401) {
-      const refreshedToken = await this.getAccessToken({ forceRefresh: true });
-      authedOpts.headers.Authorization = `Bearer ${refreshedToken}`;
-      return this.rawFetch(authedOpts);
-    }
-
-    return res;
+    super(options, '/transactions');
   }
 
   private buildUrl(params: ListTransactionsParams): string {
@@ -254,15 +159,7 @@ export class TransactionsResource implements ITransactionsResource {
     });
 
     if (status < 200 || status >= 300) {
-      const body = data as Record<string, unknown> | null;
-      const msg =
-        (body?.error as string | undefined) ??
-        (body?.message as string | undefined) ??
-        (rawBody || 'unknown error');
-      throw new LinkApiError(
-        `Failed to list transactions (${status}): ${msg}`,
-        { status, rawBody, details: data },
-      );
+      this.throwApiError('list transactions', status, data, rawBody);
     }
 
     try {
@@ -270,7 +167,7 @@ export class TransactionsResource implements ITransactionsResource {
     } catch (error) {
       const reason = error instanceof Error ? `: ${error.message}` : '';
       throw new LinkApiError(
-        `Failed to list transactions (200): invalid response shape${reason}`,
+        `Failed to list transactions (${status}): invalid response shape${reason}`,
         { status, rawBody, details: data, cause: error },
       );
     }


### PR DESCRIPTION
Extracts the HTTP transport infrastructure (rawFetch, apiFetch, 401 token refresh, verbose logging, error message extraction) from `TransactionsResource` into a shared `BaseResource` abstract class in `packages/sdk/src/resources/base.ts`.

`TransactionsResource` now extends `BaseResource` and only contains its endpoint-specific logic (URL building, response normalization). Later financial insights resources will follow the same pattern in upcoming PRs.

I ran `transactions list` and verified that it was still able to make the requests (no changes to functionality):

<img width="354" height="46" alt="image" src="https://github.com/user-attachments/assets/f410a9ce-6d6a-4b1d-8fb4-169bc9e289d2" />