### PR TITLE
Add support for the --source filter flag in the balances command

### DIFF
--- a/packages/cli/src/commands/balances/index.tsx
+++ b/packages/cli/src/commands/balances/index.tsx
@@ -29,6 +29,7 @@ export function createBalancesCli(
       const resource = createResource();
 
       const params: ListBalancesParams = {};
+      if (opts.source.length > 0) params.sources = opts.source;
       if (opts.limit !== undefined) params.limit = opts.limit;
       if (opts.startingAfter !== undefined)
         params.starting_after = opts.startingAfter;

--- a/packages/cli/src/commands/balances/schema.ts
+++ b/packages/cli/src/commands/balances/schema.ts
@@ -1,6 +1,10 @@
 import { z } from 'incur';
 
 export const listOptions = z.object({
+  source: z
+    .array(z.string())
+    .default([])
+    .describe('Filter by source ID. Repeat to include multiple sources.'),
   limit: z.coerce
     .number()
     .int()

--- a/packages/sdk/src/resources/balances.ts
+++ b/packages/sdk/src/resources/balances.ts
@@ -48,6 +48,11 @@ export class BalancesResource
   private buildUrl(params: ListBalancesParams): string {
     const url = new URL(this.endpoint);
 
+    if (params.sources !== undefined) {
+      for (const source of params.sources) {
+        url.searchParams.append('sources[]', source);
+      }
+    }
     if (params.limit !== undefined) {
       url.searchParams.set('limit', String(params.limit));
     }

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -131,6 +131,7 @@ export interface ISourcesResource {
 }
 
 export interface ListBalancesParams {
+  sources?: string[];
   limit?: number;
   starting_after?: string;
   ending_before?: string;


### PR DESCRIPTION
Allows filtering by source ID when listing balances. The repeated `--source` flag pattern matches the `transactions list` command.

<img width="588" height="118" alt="image" src="https://github.com/user-attachments/assets/366061c4-eac6-46d1-923a-dc1ac298849b" />

