### PR TITLE
feat(mpp): support decoding session challenges alongside charge

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1800,6 +1800,23 @@ describe('production mode', () => {
       'expires="2099-01-01T00:00:00Z"',
     ].join(' ');
 
+    const WWW_AUTHENTICATE_STRIPE_SESSION = [
+      'Payment id="sess_001",',
+      'realm="127.0.0.1",',
+      'method="stripe",',
+      'intent="session",',
+      `request="${Buffer.from(JSON.stringify({ networkId: 'net_001', amount: '1000', currency: 'usd', decimals: 2, paymentMethodTypes: ['card'] })).toString('base64')}",`,
+      'expires="2099-01-01T00:00:00Z"',
+    ].join(' ');
+
+    function decodeCredential(authorizationHeader: string): {
+      challenge: { intent: string };
+      payload: Record<string, unknown>;
+    } {
+      const encoded = authorizationHeader.replace(/^Payment\s+/i, '');
+      return JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+    }
+
     it('happy path: probes, gets 402, signs, retries, returns response', async () => {
       setNextResponse(200, APPROVED_SPT_REQUEST);
       setMerchantResponse(402, '{"error":"payment required"}', {
@@ -1875,6 +1892,35 @@ describe('production mode', () => {
       expect(result.exitCode).toBe(0);
       expect(merchantRequests).toHaveLength(2);
       expect(merchantRequests[1].headers.authorization).toMatch(/^Payment /);
+    });
+
+    it('signs a stripe session challenge with an open/grantedToken credential', async () => {
+      setNextResponse(200, APPROVED_SPT_REQUEST);
+      setMerchantResponse(402, '{"error":"payment required"}', {
+        'www-authenticate': WWW_AUTHENTICATE_STRIPE_SESSION,
+      });
+      setMerchantResponse(200, '{"success":true}');
+
+      const result = await runProdCli(
+        'mpp',
+        'pay',
+        `http://127.0.0.1:${merchantPort}/api/session`,
+        '--spend-request-id',
+        'lsrq_spt_001',
+        '--format',
+        'json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(merchantRequests).toHaveLength(2);
+      const authorization = merchantRequests[1].headers.authorization as string;
+      expect(authorization).toMatch(/^Payment /);
+      const credential = decodeCredential(authorization);
+      expect(credential.challenge.intent).toBe('session');
+      expect(credential.payload).toEqual({
+        action: 'open',
+        grantedToken: 'spt_test_abc123',
+      });
     });
 
     it('passthrough: no 402 returns response without signing', async () => {

--- a/packages/cli/src/commands/mpp/decode.test.ts
+++ b/packages/cli/src/commands/mpp/decode.test.ts
@@ -58,7 +58,29 @@ describe('decodeStripeChallenge', () => {
     });
   });
 
-  it('rejects headers without a stripe charge challenge', () => {
+  it('decodes a stripe session challenge', () => {
+    const header = [
+      'Payment id="sess_001", realm="merchant.example", method="stripe", intent="session",',
+      `request="${encodeRequest({
+        amount: '1000',
+        currency: 'usd',
+        methodDetails: {
+          networkId: 'net_001',
+          paymentMethodTypes: ['card'],
+        },
+      })}"`,
+    ].join(' ');
+
+    expect(decodeStripeChallenge(header)).toMatchObject({
+      id: 'sess_001',
+      realm: 'merchant.example',
+      method: 'stripe',
+      intent: 'session',
+      network_id: 'net_001',
+    });
+  });
+
+  it('rejects headers without a stripe charge or session challenge', () => {
     const header =
       'Payment id="tempo_001", realm="merchant.example", method="tempo", intent="charge", request="e30="';
 

--- a/packages/cli/src/commands/mpp/decode.ts
+++ b/packages/cli/src/commands/mpp/decode.ts
@@ -2,7 +2,7 @@ import { Challenge } from 'mppx';
 
 type StripeChargeChallenge = Challenge.Challenge<
   Record<string, unknown>,
-  'charge',
+  'charge' | 'session',
   'stripe'
 >;
 
@@ -16,7 +16,7 @@ export interface DecodedStripeChallenge {
   id: string;
   realm: string;
   method: 'stripe';
-  intent: 'charge';
+  intent: 'charge' | 'session';
   description?: string;
   digest?: string;
   expires?: string;
@@ -63,12 +63,13 @@ function resolveStripeChallenge(
 ): ResolvedStripeChallenge {
   const stripeChallenge = challenges.find(
     (challenge) =>
-      challenge.method === 'stripe' && challenge.intent === 'charge',
+      challenge.method === 'stripe' &&
+      (challenge.intent === 'charge' || challenge.intent === 'session'),
   );
 
   if (!stripeChallenge) {
     throw new Error(
-      'WWW-Authenticate header does not include a stripe charge challenge',
+      'WWW-Authenticate header does not include a stripe charge or session challenge',
     );
   }
 
@@ -121,7 +122,7 @@ export function decodeStripeChallenge(
     id: challenge.id,
     realm: challenge.realm,
     method: 'stripe',
-    intent: 'charge',
+    intent: challenge.intent,
     description: challenge.description,
     digest: challenge.digest,
     expires: challenge.expires,

--- a/packages/cli/src/commands/mpp/pay.tsx
+++ b/packages/cli/src/commands/mpp/pay.tsx
@@ -47,8 +47,20 @@ function createStripePaymentClient(spt: string) {
     },
   });
 
+  const stripeSession = Method.toClient(
+    { ...StripeMethods.charge, intent: 'session' as const },
+    {
+      async createCredential({ challenge }) {
+        return Credential.serialize({
+          challenge,
+          payload: { action: 'open', grantedToken: spt },
+        });
+      },
+    },
+  );
+
   return Mppx.create({
-    methods: [stripeCharge],
+    methods: [stripeCharge, stripeSession],
     polyfill: false,
     transport: Transport.from<RequestInit, Response>({
       name: 'stripe-http',


### PR DESCRIPTION
MPP has a concept of intent - it can either be "charge" (single payment, single API call) or "session" (single deposit of funds in a balance, multiple API calls funded by/burning down that balance).

We're starting to add support for MPP Sessions using SPTs - this PR adds intent="session" support to the MPP flow so we can at least start to test, decode, etc. Note, the MPP sdk has not yet added support for this so there's a small bit of credential construction we're doing ourselves here that I can swap out later.