### PR TITLE
Surface support url on identity verification failed errors

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -420,6 +420,37 @@ describe('production mode', () => {
       expect(next.command).toContain('--interval');
     });
 
+    it('surfaces support_url on identity_verification_failed error', async () => {
+      setNextResponse(403, {
+        error: {
+          code: 'identity_verification_failed',
+          message:
+            'Unable to verify your identity, please reach out to support to re-enable Link for agentic payments.',
+          support_url: 'https://support.link.com',
+        },
+      });
+
+      const result = await runProdCli(
+        'spend-request',
+        'create',
+        '--payment-method-id',
+        'pd_prod_test',
+        '-m',
+        'Test Merchant',
+        '--merchant-url',
+        'https://example.com',
+        '--context',
+        VALID_CONTEXT,
+        '--amount',
+        '5000',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(1);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain('https://support.link.com');
+    });
+
     it('surfaces API error messages', async () => {
       setNextResponse(422, { error: { message: 'Invalid payment details' } });
 
@@ -530,6 +561,28 @@ describe('production mode', () => {
       const next = output[0]._next as Record<string, unknown>;
       expect(next.command).toContain('spend-request retrieve');
       expect(next.command).toContain('--interval');
+    });
+
+    it('surfaces support_url on identity_verification_failed error', async () => {
+      setNextResponse(403, {
+        error: {
+          code: 'identity_verification_failed',
+          message:
+            'Unable to verify your identity, please reach out to support to re-enable Link for agentic payments.',
+          support_url: 'https://support.link.com',
+        },
+      });
+
+      const result = await runProdCli(
+        'spend-request',
+        'request-approval',
+        'lsrq_prod_001',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(1);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain('https://support.link.com');
     });
 
     it('surfaces API errors for request-approval', async () => {

--- a/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
+++ b/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
@@ -103,6 +103,54 @@ describe('spend-request', () => {
       });
     });
 
+    it('CreateSpendRequest surfaces support_url on identity_verification_failed error', async () => {
+      const error = new LinkApiError(
+        'Unable to verify your identity, please reach out to support to re-enable Link for agentic payments.',
+        {
+          status: 403,
+          code: 'identity_verification_failed',
+          details: {
+            error: {
+              code: 'identity_verification_failed',
+              message:
+                'Unable to verify your identity, please reach out to support to re-enable Link for agentic payments.',
+              support_url: 'https://support.link.com',
+            },
+          },
+        },
+      );
+      const repo = sanitizeResource({
+        createSpendRequest: vi.fn(async () => {
+          throw error;
+        }),
+        getSpendRequest: vi.fn(),
+        updateSpendRequest: vi.fn(),
+        requestApproval: vi.fn(),
+        cancelSpendRequest: vi.fn(),
+      } as unknown as ISpendRequestResource);
+
+      const { lastFrame } = render(
+        <CreateSpendRequest
+          repository={repo}
+          params={{
+            payment_details: 'pm_1',
+            amount: 200100,
+            currency: 'usd',
+            merchant_name: 'Stripe Press',
+            merchant_url: 'https://press.stripe.com',
+            context: 'x'.repeat(100),
+          }}
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Failed to create spend request');
+        expect(frame).toContain('https://support.link.com');
+      });
+    });
+
     it('RequestApproval surfaces verification_url on additional_verification_required error', async () => {
       const error = new LinkApiError(
         'Consumer must complete additional verification before creating spend requests.',
@@ -141,6 +189,47 @@ describe('spend-request', () => {
         const frame = lastFrame();
         expect(frame).toContain('Failed to request approval');
         expect(frame).toContain('https://app.link.com/finish_setup');
+      });
+    });
+
+    it('RequestApproval surfaces support_url on identity_verification_failed error', async () => {
+      const error = new LinkApiError(
+        'Unable to verify your identity, please reach out to support to re-enable Link for agentic payments.',
+        {
+          status: 403,
+          code: 'identity_verification_failed',
+          details: {
+            error: {
+              code: 'identity_verification_failed',
+              message:
+                'Unable to verify your identity, please reach out to support to re-enable Link for agentic payments.',
+              support_url: 'https://support.link.com',
+            },
+          },
+        },
+      );
+      const repo = sanitizeResource({
+        createSpendRequest: vi.fn(),
+        getSpendRequest: vi.fn(),
+        updateSpendRequest: vi.fn(),
+        requestApproval: vi.fn(async () => {
+          throw error;
+        }),
+        cancelSpendRequest: vi.fn(),
+      } as unknown as ISpendRequestResource);
+
+      const { lastFrame } = render(
+        <RequestApproval
+          repository={repo}
+          id="sr_test"
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Failed to request approval');
+        expect(frame).toContain('https://support.link.com');
       });
     });
   });

--- a/packages/cli/src/commands/spend-request/create.tsx
+++ b/packages/cli/src/commands/spend-request/create.tsx
@@ -37,6 +37,7 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
   const [request, setRequest] = useState<SpendRequest | null>(null);
   const [error, setError] = useState<string>('');
   const [verificationUrl, setVerificationUrl] = useState<string>('');
+  const [supportUrl, setSupportUrl] = useState<string>('');
   const [outputFilePath, setOutputFilePath] = useState<string | null>(null);
   const [fileError, setFileError] = useState<string>('');
 
@@ -83,9 +84,13 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
       } catch (err) {
         setError((err as Error).message);
         if (err instanceof LinkApiError) {
-          const url = (err.details as { error?: { verification_url?: string } })
-            ?.error?.verification_url;
-          if (url) setVerificationUrl(url);
+          const errDetail = err.details as {
+            error?: { verification_url?: string; support_url?: string };
+          };
+          if (errDetail?.error?.verification_url)
+            setVerificationUrl(errDetail.error.verification_url);
+          if (errDetail?.error?.support_url)
+            setSupportUrl(errDetail.error.support_url);
         }
         setStatus('error');
         setTimeout(() => completeAndExit(null), DISPLAY_DELAY_MS);
@@ -129,6 +134,11 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
         {verificationUrl && (
           <Text color="red">
             Complete additional verification at: {verificationUrl}
+          </Text>
+        )}
+        {supportUrl && (
+          <Text color="red">
+            Identity verification failed. Contact support at: {supportUrl}
           </Text>
         )}
       </Box>

--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -204,12 +204,22 @@ export function createSpendRequestCli(
       } catch (err) {
         if (err instanceof LinkApiError) {
           const apiErr = err.details as {
-            error?: { code?: string; verification_url?: string };
+            error?: {
+              code?: string;
+              verification_url?: string;
+              support_url?: string;
+            };
           };
           if (apiErr?.error?.verification_url) {
             return c.error({
               code: err.code,
               message: `${err.message} Verification URL: ${apiErr.error.verification_url}`,
+            });
+          }
+          if (apiErr?.error?.support_url) {
+            return c.error({
+              code: err.code,
+              message: `${err.message} Support URL: ${apiErr.error.support_url}`,
             });
           }
         }
@@ -329,12 +339,22 @@ export function createSpendRequestCli(
       } catch (err) {
         if (err instanceof LinkApiError) {
           const apiErr = err.details as {
-            error?: { code?: string; verification_url?: string };
+            error?: {
+              code?: string;
+              verification_url?: string;
+              support_url?: string;
+            };
           };
           if (apiErr?.error?.verification_url) {
             return c.error({
               code: err.code,
               message: `${err.message} Verification URL: ${apiErr.error.verification_url}`,
+            });
+          }
+          if (apiErr?.error?.support_url) {
+            return c.error({
+              code: err.code,
+              message: `${err.message} Support URL: ${apiErr.error.support_url}`,
             });
           }
         }

--- a/packages/cli/src/commands/spend-request/request-approval.tsx
+++ b/packages/cli/src/commands/spend-request/request-approval.tsx
@@ -26,6 +26,7 @@ export const RequestApproval: React.FC<RequestApprovalProps> = ({
   const [result, setResult] = useState<SpendRequest | null>(null);
   const [error, setError] = useState<string>('');
   const [verificationUrl, setVerificationUrl] = useState<string>('');
+  const [supportUrl, setSupportUrl] = useState<string>('');
   const { exit } = useApp();
 
   const completeAndExit = useCallback(
@@ -59,9 +60,13 @@ export const RequestApproval: React.FC<RequestApprovalProps> = ({
       } catch (err) {
         setError((err as Error).message);
         if (err instanceof LinkApiError) {
-          const url = (err.details as { error?: { verification_url?: string } })
-            ?.error?.verification_url;
-          if (url) setVerificationUrl(url);
+          const errDetail = err.details as {
+            error?: { verification_url?: string; support_url?: string };
+          };
+          if (errDetail?.error?.verification_url)
+            setVerificationUrl(errDetail.error.verification_url);
+          if (errDetail?.error?.support_url)
+            setSupportUrl(errDetail.error.support_url);
         }
         setStatus('error');
         setTimeout(() => {
@@ -92,6 +97,11 @@ export const RequestApproval: React.FC<RequestApprovalProps> = ({
         {verificationUrl && (
           <Text color="red">
             Complete additional verification at: {verificationUrl}
+          </Text>
+        )}
+        {supportUrl && (
+          <Text color="red">
+            Identity verification failed. Contact support at: {supportUrl}
           </Text>
         )}
       </Box>


### PR DESCRIPTION
The server now returns `support_url` (instead of `verification_url`) when IDV escalation fails with `identity_verification_failed`. Previously link-cli had no handling for this path, so the error would surface without the support link.