### PR TITLE
Harden the security of the serve command

### DIFF
--- a/.changeset/serve-loopback-security.md
+++ b/.changeset/serve-loopback-security.md
@@ -1,5 +1,5 @@
 ---
-"@stripe/link-cli": patch
+"@stripe/link-cli": minor
 ---
 
 security: `serve` now binds to `127.0.0.1` by default (opt out with `--host`), only serves the `/mcp` endpoint and skills discovery (all other paths 404 instead of reaching the CLI command router), and validates request `Origin` instead of sending wildcard CORS. This prevents an unauthenticated HTTP caller that can reach the port from invoking the CLI owner's authenticated Link session.

--- a/.changeset/serve-loopback-security.md
+++ b/.changeset/serve-loopback-security.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": patch
+---
+
+security: `serve` now binds to `127.0.0.1` by default (opt out with `--host`), only serves the `/mcp` endpoint and skills discovery (all other paths 404 instead of reaching the CLI command router), and validates request `Origin` instead of sending wildcard CORS. This prevents an unauthenticated HTTP caller that can reach the port from invoking the CLI owner's authenticated Link session.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,9 @@ Key input field notes:
 
 - `onboard` — Guided setup: authenticates (skips if already logged in), checks payment methods (prompts to add one if missing, shows picker if multiple), shows app download QR code, then runs the full demo. Requires a TTY.
 
+### serve command
+
+- `serve [--port <n>] [--host <host>]` — HTTP server that exposes the CLI's MCP endpoint. Implemented in `packages/cli/src/commands/serve/index.ts`. The handler forwards to `rootCli.fetch()` (incur), but is a **privilege boundary**: `requireAuth` only proves the CLI *owner* is authenticated, not that the HTTP caller is authorized.
 
 ## Code Conventions
 

--- a/README.md
+++ b/README.md
@@ -63,11 +63,12 @@ Link CLI can run as a local MCP server. Add the following to your MCP client con
 Use `serve` to expose link-cli as an MCP endpoint over HTTP. This is useful for remote or containerised agents that can't launch a local subprocess.
 
 ```bash
-link-cli serve            # listens on port 54321 by default
+link-cli serve            # binds 127.0.0.1:54321 (loopback only)
 link-cli serve --port 8080
+link-cli serve --host 0.0.0.0   # expose beyond localhost (see warning below)
 ```
 
-The MCP endpoint is available at `/mcp` on the chosen port.
+The server only handles the `/mcp` endpoint (and `/.well-known/skills/` discovery); any other path returns `404`. It binds to `127.0.0.1` by default so only the local host can reach it. Anyone who can reach the port can use this CLI's authenticated Link session, so only override `--host` on a trusted, isolated network — doing so prints a warning.
 
 ## Quickstart
 

--- a/packages/cli/src/__tests__/serve.test.ts
+++ b/packages/cli/src/__tests__/serve.test.ts
@@ -1,0 +1,155 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import http from 'node:http';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const CLI_PATH = new URL('../../dist/cli.js', import.meta.url).pathname;
+
+const VICTIM_TOKEN = 'victim_test_token_123';
+
+interface ApiRequestLog {
+  method: string;
+  url: string;
+  authorization: string | undefined;
+  body: string;
+}
+
+let mockApi: http.Server;
+let mockApiPort: number;
+let apiRequests: ApiRequestLog[];
+let cli: ChildProcess | undefined;
+let servePort: number;
+
+function listen(server: http.Server): Promise<number> {
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve((server.address() as { port: number }).port);
+    });
+  });
+}
+
+function closeServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+// Grab an ephemeral port, then release it so serve can bind it.
+async function freePort(): Promise<number> {
+  const tmp = http.createServer();
+  const port = await listen(tmp);
+  await closeServer(tmp);
+  return port;
+}
+
+function waitForListening(child: ChildProcess): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let stderr = '';
+    const timer = setTimeout(
+      () => reject(new Error(`serve did not start\n${stderr}`)),
+      10_000,
+    );
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+      if (stderr.includes('link-cli MCP server listening')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timer);
+      reject(new Error(`serve exited early code=${code} signal=${signal}`));
+    });
+  });
+}
+
+describe('serve command security', () => {
+  beforeEach(async () => {
+    apiRequests = [];
+    mockApi = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        apiRequests.push({
+          method: req.method ?? '',
+          url: req.url ?? '',
+          authorization: req.headers.authorization,
+          body: Buffer.concat(chunks).toString(),
+        });
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    mockApiPort = await listen(mockApi);
+    servePort = await freePort();
+
+    cli = spawn('node', [CLI_PATH, 'serve', '--port', String(servePort)], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        LINK_ACCESS_TOKEN: VICTIM_TOKEN,
+        LINK_NO_REFRESH: '1',
+        LINK_API_BASE_URL: `http://127.0.0.1:${mockApiPort}`,
+        LINK_AUTH_BASE_URL: `http://127.0.0.1:${mockApiPort}`,
+        NO_UPDATE_NOTIFIER: '1',
+      },
+    });
+    await waitForListening(cli);
+  });
+
+  afterEach(async () => {
+    if (cli && !cli.killed) {
+      cli.kill('SIGTERM');
+      await new Promise<void>((resolve) => cli?.once('exit', () => resolve()));
+    }
+    cli = undefined;
+    await closeServer(mockApi);
+  });
+
+  it('404s an arbitrary CLI command path and never uses the token', async () => {
+    const res = await fetch(
+      `http://127.0.0.1:${servePort}/user-info/retrieve`,
+      { headers: { Accept: 'application/json' } },
+    );
+    expect(res.status).toBe(404);
+    expect(res.headers.get('access-control-allow-origin')).not.toBe('*');
+    expect(apiRequests).toHaveLength(0);
+  });
+
+  it('404s a state-changing command path and never uses the token', async () => {
+    const res = await fetch(
+      `http://127.0.0.1:${servePort}/spend-request/update/spr_poc_123`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount: 4242 }),
+      },
+    );
+    expect(res.status).toBe(404);
+    expect(apiRequests).toHaveLength(0);
+  });
+
+  it('routes /mcp to the MCP transport (not gated as 404)', async () => {
+    const res = await fetch(`http://127.0.0.1:${servePort}/mcp`, {
+      headers: { Accept: 'application/json, text/event-stream' },
+    });
+    expect(res.status).not.toBe(404);
+  });
+
+  it('rejects cross-origin requests with 403', async () => {
+    const res = await fetch(`http://127.0.0.1:${servePort}/mcp`, {
+      headers: { Origin: 'https://attacker.example' },
+    });
+    expect(res.status).toBe(403);
+    expect(res.headers.get('access-control-allow-origin')).not.toBe('*');
+    expect(apiRequests).toHaveLength(0);
+  });
+
+  it('allows loopback browser origins without wildcard CORS', async () => {
+    const res = await fetch(`http://127.0.0.1:${servePort}/mcp`, {
+      method: 'OPTIONS',
+      headers: { Origin: 'http://localhost:3000' },
+    });
+    expect(res.status).toBe(204);
+    expect(res.headers.get('access-control-allow-origin')).toBe(
+      'http://localhost:3000',
+    );
+  });
+});

--- a/packages/cli/src/commands/serve/index.ts
+++ b/packages/cli/src/commands/serve/index.ts
@@ -43,6 +43,33 @@ async function sendWebResponse(
   res.end(Buffer.from(buffer));
 }
 
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', '::1', 'localhost']);
+
+function isLoopbackHost(host: string): boolean {
+  return LOOPBACK_HOSTS.has(host.toLowerCase());
+}
+
+// Returns true when the request's Origin is safe to serve. Requests without an
+// Origin (non-browser callers such as MCP clients or curl) are allowed; browser
+// requests are only allowed from loopback origins.
+function isAllowedOrigin(origin: string | undefined): boolean {
+  if (!origin) return true;
+  try {
+    return isLoopbackHost(new URL(origin).hostname);
+  } catch {
+    return false;
+  }
+}
+
+// Only the MCP transport (/mcp) and Agent Skills discovery
+// (/.well-known/skills/, GET) are intentionally exposed.
+function isAllowedRoute(method: string, pathname: string): boolean {
+  if (pathname === '/mcp') return true;
+  if (pathname.startsWith('/.well-known/skills/') && method === 'GET')
+    return true;
+  return false;
+}
+
 export function createServeCli(rootCli: {
   fetch: (req: Request) => Promise<Response>;
 }) {
@@ -51,13 +78,32 @@ export function createServeCli(rootCli: {
       'Start an HTTP server exposing link-cli as an MCP endpoint at /mcp',
     options: z.object({
       port: z.coerce.number().default(54321).describe('Port to listen on'),
+      host: z
+        .string()
+        .default('127.0.0.1')
+        .describe(
+          'Host/interface to bind. Defaults to loopback; set explicitly (e.g. 0.0.0.0) to expose beyond localhost.',
+        ),
     }),
     async run(c) {
-      const { port } = c.options;
+      const { port, host } = c.options;
 
       const server = createServer(
         async (req: IncomingMessage, res: ServerResponse) => {
-          res.setHeader('Access-Control-Allow-Origin', '*');
+          const origin = req.headers.origin;
+
+          if (!isAllowedOrigin(origin)) {
+            res.writeHead(403, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'forbidden origin' }));
+            return;
+          }
+
+          // Reflect the specific allowed origin (never `*`) so responses stay
+          // scoped to loopback browser callers.
+          if (origin) {
+            res.setHeader('Access-Control-Allow-Origin', origin);
+            res.setHeader('Vary', 'Origin');
+          }
           res.setHeader(
             'Access-Control-Allow-Methods',
             'GET, POST, DELETE, OPTIONS',
@@ -70,6 +116,14 @@ export function createServeCli(rootCli: {
           if (req.method === 'OPTIONS') {
             res.writeHead(204);
             res.end();
+            return;
+          }
+
+          const pathname = new URL(req.url ?? '/', `http://localhost:${port}`)
+            .pathname;
+          if (!isAllowedRoute(req.method ?? 'GET', pathname)) {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'not found' }));
             return;
           }
 
@@ -87,9 +141,14 @@ export function createServeCli(rootCli: {
 
       await new Promise<void>((resolve, reject) => {
         server.on('error', reject);
-        server.listen(port, () => {
+        server.listen(port, host, () => {
+          if (!isLoopbackHost(host)) {
+            process.stderr.write(
+              `WARNING: link-cli serve is bound to ${host}, which may be reachable beyond localhost.\nAny caller that can reach this port can use the authenticated Link session of this CLI. Only do this on a trusted, isolated network.\n`,
+            );
+          }
           process.stderr.write(
-            `link-cli MCP server listening on http://localhost:${port}/mcp\n`,
+            `link-cli MCP server listening on http://${host}:${port}/mcp\n`,
           );
         });
       });

--- a/plugins/link/.claude-plugin/plugin.json
+++ b/plugins/link/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "link",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Authenticate with Link, create spend requests, and retrieve one-time-use card or shared payment token credentials for user-approved purchases.",
   "author": {
     "name": "Stripe"

--- a/plugins/link/.codex-plugin/plugin.json
+++ b/plugins/link/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "link",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Secure, one-time-use payment credentials from Link",
   "author": {
     "name": "Stripe",

--- a/plugins/link/.cursor-plugin/plugin.json
+++ b/plugins/link/.cursor-plugin/plugin.json
@@ -9,21 +9,9 @@
   "homepage": "https://link.com/agents",
   "repository": "https://github.com/stripe/link-cli",
   "license": "MIT",
-  "keywords": [
-    "payment",
-    "link",
-    "stripe",
-    "agentic-commerce",
-    "mcp"
-  ],
+  "keywords": ["payment", "link", "stripe", "agentic-commerce", "mcp"],
   "category": "payments",
-  "tags": [
-    "payments",
-    "stripe",
-    "link",
-    "agents",
-    "mcp"
-  ],
+  "tags": ["payments", "stripe", "link", "agents", "mcp"],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/link/.cursor-plugin/plugin.json
+++ b/plugins/link/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "link",
   "displayName": "Stripe Link",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Get secure, one-time-use payment credentials from a Link wallet so agents can complete purchases on your behalf.",
   "author": {
     "name": "Stripe"
@@ -9,9 +9,21 @@
   "homepage": "https://link.com/agents",
   "repository": "https://github.com/stripe/link-cli",
   "license": "MIT",
-  "keywords": ["payment", "link", "stripe", "agentic-commerce", "mcp"],
+  "keywords": [
+    "payment",
+    "link",
+    "stripe",
+    "agentic-commerce",
+    "mcp"
+  ],
   "category": "payments",
-  "tags": ["payments", "stripe", "link", "agents", "mcp"],
+  "tags": [
+    "payments",
+    "stripe",
+    "link",
+    "agents",
+    "mcp"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: 0.7.3
+version: 0.9.0
 name: create-payment-credential
 description: |
   Gets secure, one-time-use payment credentials (cards, tokens) from a Link wallet so agents can complete purchases on behalf of users. Use when the user says "get me a card", "buy something", "pay for X", "make a purchase", "I need to pay", "complete checkout", or asks to transact on any merchant site. Use when the user asks to connect or log in to or sign up for their Link account.


### PR DESCRIPTION
Security improvements for the `serve` command/the MCP server that the CLI can expose. Namely:
- Bind to localhost by default, unless a `host` is explicitly provided to the `serve` command
- Ensure the MCP server only exposes `/mcp` and `/.well-known/skills` routes, rather than arbitrary routes/commands
- Scope origin allowlist + CORS to be less permissive if not serving on `localhost` 