### PR TITLE
Auto-install skill files on npm install

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,6 +8,7 @@
   "files": [
     "dist",
     "!dist/sea",
+    "postinstall.mjs",
     "README.md",
     "LICENSE"
   ],
@@ -24,6 +25,7 @@
   "scripts": {
     "build": "tsup",
     "build:sea": "tsup --config tsup.sea.config.ts",
+    "postinstall": "node postinstall.mjs",
     "prepack": "cp ../../README.md ../../LICENSE .",
     "typecheck": "tsc",
     "test": "vitest run",

--- a/packages/cli/postinstall.mjs
+++ b/packages/cli/postinstall.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+// Refresh the create-payment-credential skill whenever the CLI is (re)installed
+// or upgraded via npm. Delegates to the openclaw `skills` CLI so the skill file
+// stays in sync with the installed CLI version. Must never fail the install.
+
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const REPO = 'stripe/link-cli';
+
+function run() {
+  // Skip when running from the source monorepo (dev `pnpm install`). Installed
+  // copies live under node_modules; the dev tree does not.
+  if (!fileURLToPath(import.meta.url).includes('node_modules')) {
+    return;
+  }
+
+  if (process.env.CI || process.env.LINK_CLI_SKIP_SKILL_INSTALL) {
+    return;
+  }
+
+  process.stdout.write(
+    'link-cli: refreshing the create-payment-credential skill…\n',
+  );
+
+  const result = spawnSync(
+    'npx',
+    ['--yes', 'skills', 'add', REPO, '-g', '-y'],
+    {
+      stdio: 'inherit',
+      timeout: 60_000,
+    },
+  );
+
+  if (result.error || result.status !== 0) {
+    process.stdout.write(
+      `link-cli: skipped skill refresh; run 'npx skills add ${REPO}' manually.\n`,
+    );
+  }
+}
+
+try {
+  run();
+} catch {
+  // Never fail the install.
+}
+
+process.exit(0);


### PR DESCRIPTION
Add a postinstall script that copies the SKILL.md into ~/.claude/skills/ and ~/.codex/skills/ so the skill is available globally without being inside the repo. 

This is ~copied from the `tempo` CLI; agents will automatically load this skill when relevant, so this should greatly help agents complete checkout with link-cli!