### PR TITLE
add activity_url and transaction_id to SpendRequest

### DIFF
--- a/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
+++ b/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
@@ -234,6 +234,94 @@ describe('spend-request', () => {
     });
   });
 
+  describe('activity_url', () => {
+    it('RetrieveSpendRequest shows activity_url in finalized phase', async () => {
+      const request = makeSpendRequest({
+        status: 'succeeded',
+        activity_url: 'https://activity.link.com/tx_123',
+      });
+      const repo = makeMockRepo(request);
+
+      const { lastFrame } = render(
+        <RetrieveSpendRequest
+          repository={repo}
+          id="sr_test"
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Activity URL');
+        expect(frame).toContain('https://activity.link.com/tx_123');
+      });
+    });
+
+    it('RetrieveSpendRequest shows link_transaction_id in finalized phase', async () => {
+      const request = makeSpendRequest({
+        status: 'succeeded',
+        link_transaction_id: 'ltxn_abc123',
+      });
+      const repo = makeMockRepo(request);
+
+      const { lastFrame } = render(
+        <RetrieveSpendRequest
+          repository={repo}
+          id="sr_test"
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Transaction ID');
+        expect(frame).toContain('ltxn_abc123');
+      });
+    });
+
+    it('RetrieveSpendRequest omits activity_url when absent in finalized phase', async () => {
+      const request = makeSpendRequest({ status: 'succeeded' });
+      const repo = makeMockRepo(request);
+
+      const { lastFrame } = render(
+        <RetrieveSpendRequest
+          repository={repo}
+          id="sr_test"
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('terminal status');
+        expect(frame).not.toContain('Activity URL');
+      });
+    });
+
+    it('RetrieveSpendRequest shows activity_url in approved/success phase', async () => {
+      const request = makeSpendRequest({
+        status: 'approved',
+        activity_url: 'https://activity.link.com/tx_456',
+      });
+      const repo = makeMockRepo(request);
+
+      const { lastFrame } = render(
+        <RetrieveSpendRequest
+          repository={repo}
+          id="sr_test"
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Activity URL');
+        expect(frame).toContain('https://activity.link.com/tx_456');
+      });
+    });
+
+  });
+
   describe('sanitization', () => {
     it('CreateSpendRequest sanitizes merchant_name and line_items', async () => {
       const request = makeSpendRequest();

--- a/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
+++ b/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
@@ -279,8 +279,11 @@ describe('spend-request', () => {
       });
     });
 
-    it('RetrieveSpendRequest omits activity_url when absent in finalized phase', async () => {
-      const request = makeSpendRequest({ status: 'succeeded' });
+    it('RetrieveSpendRequest omits activity_url on failed status even when present', async () => {
+      const request = makeSpendRequest({
+        status: 'failed',
+        activity_url: 'https://activity.link.com/tx_123',
+      });
       const repo = makeMockRepo(request);
 
       const { lastFrame } = render(
@@ -298,11 +301,8 @@ describe('spend-request', () => {
       });
     });
 
-    it('RetrieveSpendRequest shows activity_url in approved/success phase', async () => {
-      const request = makeSpendRequest({
-        status: 'approved',
-        activity_url: 'https://activity.link.com/tx_456',
-      });
+    it('RetrieveSpendRequest omits activity_url when absent in finalized phase', async () => {
+      const request = makeSpendRequest({ status: 'succeeded' });
       const repo = makeMockRepo(request);
 
       const { lastFrame } = render(
@@ -315,8 +315,8 @@ describe('spend-request', () => {
 
       await vi.waitFor(() => {
         const frame = lastFrame();
-        expect(frame).toContain('Activity URL');
-        expect(frame).toContain('https://activity.link.com/tx_456');
+        expect(frame).toContain('terminal status');
+        expect(frame).not.toContain('Activity URL');
       });
     });
 

--- a/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
+++ b/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
@@ -319,7 +319,6 @@ describe('spend-request', () => {
         expect(frame).not.toContain('Activity URL');
       });
     });
-
   });
 
   describe('sanitization', () => {

--- a/packages/cli/src/commands/spend-request/retrieve.tsx
+++ b/packages/cli/src/commands/spend-request/retrieve.tsx
@@ -295,7 +295,7 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
               </Text>
             </Box>
           )}
-          {request?.activity_url && (
+          {request?.status === 'succeeded' && request?.activity_url && (
             <Box marginTop={1}>
               <Text>
                 Activity URL:{' '}
@@ -403,24 +403,6 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
                 <Text bold>{request.payment_status_details.decline_code}</Text>
               </Text>
             )}
-          </Box>
-        )}
-        {request?.link_transaction_id && (
-          <Box marginTop={1}>
-            <Text>
-              Transaction ID:{' '}
-              <Text bold>{request.link_transaction_id}</Text>
-            </Text>
-          </Box>
-        )}
-        {request?.activity_url && (
-          <Box marginTop={1}>
-            <Text>
-              Activity URL:{' '}
-              <Text bold color="cyan">
-                {request.activity_url}
-              </Text>
-            </Text>
           </Box>
         )}
         {request?.shared_payment_token && (

--- a/packages/cli/src/commands/spend-request/retrieve.tsx
+++ b/packages/cli/src/commands/spend-request/retrieve.tsx
@@ -287,6 +287,24 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
               )}
             </Box>
           )}
+          {request?.link_transaction_id && (
+            <Box marginTop={1}>
+              <Text>
+                Transaction ID:{' '}
+                <Text bold>{request.link_transaction_id}</Text>
+              </Text>
+            </Box>
+          )}
+          {request?.activity_url && (
+            <Box marginTop={1}>
+              <Text>
+                Activity URL:{' '}
+                <Text bold color="cyan">
+                  {request.activity_url}
+                </Text>
+              </Text>
+            </Box>
+          )}
         </Box>
       </Box>
     );
@@ -385,6 +403,24 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
                 <Text bold>{request.payment_status_details.decline_code}</Text>
               </Text>
             )}
+          </Box>
+        )}
+        {request?.link_transaction_id && (
+          <Box marginTop={1}>
+            <Text>
+              Transaction ID:{' '}
+              <Text bold>{request.link_transaction_id}</Text>
+            </Text>
+          </Box>
+        )}
+        {request?.activity_url && (
+          <Box marginTop={1}>
+            <Text>
+              Activity URL:{' '}
+              <Text bold color="cyan">
+                {request.activity_url}
+              </Text>
+            </Text>
           </Box>
         )}
         {request?.shared_payment_token && (

--- a/packages/cli/src/commands/spend-request/retrieve.tsx
+++ b/packages/cli/src/commands/spend-request/retrieve.tsx
@@ -290,8 +290,7 @@ export const RetrieveSpendRequest: React.FC<RetrieveSpendRequestProps> = ({
           {request?.link_transaction_id && (
             <Box marginTop={1}>
               <Text>
-                Transaction ID:{' '}
-                <Text bold>{request.link_transaction_id}</Text>
+                Transaction ID: <Text bold>{request.link_transaction_id}</Text>
               </Text>
             </Box>
           )}

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -132,6 +132,8 @@ export interface SpendRequest {
   shared_payment_token?: SharedPaymentToken;
   link_pay_token?: string;
   payment_status_details?: PaymentStatusDetails | null;
+  link_transaction_id?: string;
+  activity_url?: string;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
Surfaces link_transaction_id and activity_url on finalized spend requests in the retrieve command. When a spend request reaches succeeded status, the CLI now displays an activity URL alongside the existing payment status details. Both fields are optional and only rendered when present in the response