### PR TITLE
Press enter to open verification URL in browser on spend request step-up failure

### DIFF
--- a/packages/cli/src/commands/spend-request/create.tsx
+++ b/packages/cli/src/commands/spend-request/create.tsx
@@ -4,12 +4,13 @@ import type {
   SpendRequest,
 } from '@stripe/link-sdk';
 import { LinkApiError } from '@stripe/link-sdk';
-import { Box, Text, useApp } from 'ink';
+import { Box, Text, useApp, useInput } from 'ink';
 import Spinner from 'ink-spinner';
 import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { DISPLAY_DELAY_MS } from '../../utils/constants';
 import { writeCredentialFile } from '../../utils/credential-output';
+import { openUrl } from '../../utils/open-url';
 import { AppDownloadQrCodes } from './app-download-qr-codes';
 import { ApprovalWaitingView } from './approval-waiting-view';
 import { useApprovalPolling } from './use-approval-polling';
@@ -31,18 +32,26 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
   force,
   onComplete,
 }) => {
+  const { exit } = useApp();
+
   const [status, setStatus] = useState<
-    'creating' | 'waiting' | 'polling' | 'success' | 'error'
+    | 'creating'
+    | 'waiting'
+    | 'polling'
+    | 'success'
+    | 'error'
+    | 'verification_required'
+    | 'opened'
   >('creating');
   const [request, setRequest] = useState<SpendRequest | null>(null);
   const [error, setError] = useState<string>('');
   const [verificationUrl, setVerificationUrl] = useState<string>('');
   const [supportUrl, setSupportUrl] = useState<string>('');
+  const [countdown, setCountdown] = useState(30);
   const [outputFilePath, setOutputFilePath] = useState<string | null>(null);
   const [fileError, setFileError] = useState<string>('');
 
   const approvalUrl = request?.approval_url ?? '';
-  const { exit } = useApp();
 
   const completeAndExit = useCallback(
     (result: SpendRequest | null) => {
@@ -69,6 +78,28 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
     onError,
   });
 
+  useInput((_, key) => {
+    if (
+      key.return &&
+      (verificationUrl || supportUrl) &&
+      status === 'verification_required'
+    ) {
+      openUrl(verificationUrl || supportUrl);
+      setStatus('opened');
+      setTimeout(() => completeAndExit(null), DISPLAY_DELAY_MS);
+    }
+  });
+
+  useEffect(() => {
+    if (status !== 'verification_required') return;
+    if (countdown <= 0) {
+      completeAndExit(null);
+      return;
+    }
+    const timer = setTimeout(() => setCountdown((c) => c - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [status, countdown, completeAndExit]);
+
   useEffect(() => {
     const create = async () => {
       try {
@@ -91,6 +122,13 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
             setVerificationUrl(errDetail.error.verification_url);
           if (errDetail?.error?.support_url)
             setSupportUrl(errDetail.error.support_url);
+          if (
+            errDetail?.error?.verification_url ||
+            errDetail?.error?.support_url
+          ) {
+            setStatus('verification_required');
+            return;
+          }
         }
         setStatus('error');
         setTimeout(() => completeAndExit(null), DISPLAY_DELAY_MS);
@@ -116,6 +154,43 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
       .catch((err) => setFileError((err as Error).message));
   }, [status, outputFile, force, request]);
 
+  if (status === 'verification_required') {
+    const url = verificationUrl || supportUrl;
+    return (
+      <Box flexDirection="column">
+        <Text color="red">✗ Failed to create spend request</Text>
+        <Text color="red">{error}</Text>
+        <Box
+          flexDirection="column"
+          borderStyle="round"
+          borderColor="cyan"
+          paddingX={2}
+          paddingY={1}
+          marginTop={1}
+        >
+          <Text>
+            Open:{' '}
+            <Text bold color="cyan">
+              {url}
+            </Text>
+          </Text>
+          <Text dimColor>Press Enter to open in browser</Text>
+          <Text dimColor>Exiting in {countdown}s...</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (status === 'opened') {
+    return (
+      <Box flexDirection="column">
+        <Text color="red">✗ Failed to create spend request</Text>
+        <Text color="red">{error}</Text>
+        <Text color="green">✓ Opened verification URL in browser</Text>
+      </Box>
+    );
+  }
+
   if (status === 'creating') {
     return (
       <Box>
@@ -131,16 +206,6 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
       <Box flexDirection="column">
         <Text color="red">✗ Failed to create spend request</Text>
         <Text color="red">{error}</Text>
-        {verificationUrl && (
-          <Text color="red">
-            Complete additional verification at: {verificationUrl}
-          </Text>
-        )}
-        {supportUrl && (
-          <Text color="red">
-            Identity verification failed. Contact support at: {supportUrl}
-          </Text>
-        )}
       </Box>
     );
   }

--- a/packages/cli/src/commands/spend-request/request-approval.tsx
+++ b/packages/cli/src/commands/spend-request/request-approval.tsx
@@ -1,10 +1,11 @@
-import { LinkApiError } from '@stripe/link-sdk';
 import type { ISpendRequestResource, SpendRequest } from '@stripe/link-sdk';
-import { Box, Text, useApp } from 'ink';
+import { LinkApiError } from '@stripe/link-sdk';
+import { Box, Text, useApp, useInput } from 'ink';
 import Spinner from 'ink-spinner';
 import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { DISPLAY_DELAY_MS } from '../../utils/constants';
+import { openUrl } from '../../utils/open-url';
 import { ApprovalWaitingView } from './approval-waiting-view';
 import { useApprovalPolling } from './use-approval-polling';
 
@@ -19,23 +20,31 @@ export const RequestApproval: React.FC<RequestApprovalProps> = ({
   id,
   onComplete,
 }) => {
+  const { exit } = useApp();
+
+  const completeAndExit = useCallback(
+    (result: SpendRequest | null) => {
+      onComplete(result);
+      exit();
+    },
+    [onComplete, exit],
+  );
+
   const [status, setStatus] = useState<
-    'requesting' | 'waiting' | 'polling' | 'success' | 'error'
+    | 'requesting'
+    | 'waiting'
+    | 'polling'
+    | 'success'
+    | 'error'
+    | 'verification_required'
+    | 'opened'
   >('requesting');
   const [approvalUrl, setApprovalUrl] = useState<string>('');
   const [result, setResult] = useState<SpendRequest | null>(null);
   const [error, setError] = useState<string>('');
   const [verificationUrl, setVerificationUrl] = useState<string>('');
   const [supportUrl, setSupportUrl] = useState<string>('');
-  const { exit } = useApp();
-
-  const completeAndExit = useCallback(
-    (result: SpendRequest) => {
-      onComplete(result);
-      exit();
-    },
-    [onComplete, exit],
-  );
+  const [countdown, setCountdown] = useState(30);
 
   const onSuccess = useCallback((r: SpendRequest) => setResult(r), []);
   const onError = useCallback((msg: string) => setError(msg), []);
@@ -50,6 +59,28 @@ export const RequestApproval: React.FC<RequestApprovalProps> = ({
     onSuccess,
     onError,
   });
+
+  useInput((_, key) => {
+    if (
+      key.return &&
+      (verificationUrl || supportUrl) &&
+      status === 'verification_required'
+    ) {
+      openUrl(verificationUrl || supportUrl);
+      setStatus('opened');
+      setTimeout(() => completeAndExit(null), DISPLAY_DELAY_MS);
+    }
+  });
+
+  useEffect(() => {
+    if (status !== 'verification_required') return;
+    if (countdown <= 0) {
+      completeAndExit(null);
+      return;
+    }
+    const timer = setTimeout(() => setCountdown((c) => c - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [status, countdown, completeAndExit]);
 
   useEffect(() => {
     const request = async () => {
@@ -67,6 +98,13 @@ export const RequestApproval: React.FC<RequestApprovalProps> = ({
             setVerificationUrl(errDetail.error.verification_url);
           if (errDetail?.error?.support_url)
             setSupportUrl(errDetail.error.support_url);
+          if (
+            errDetail?.error?.verification_url ||
+            errDetail?.error?.support_url
+          ) {
+            setStatus('verification_required');
+            return;
+          }
         }
         setStatus('error');
         setTimeout(() => {
@@ -77,7 +115,44 @@ export const RequestApproval: React.FC<RequestApprovalProps> = ({
     };
 
     request();
-  }, [repository, id, exit, onComplete]);
+  }, [repository, id, onComplete, exit]);
+
+  if (status === 'verification_required') {
+    const url = verificationUrl || supportUrl;
+    return (
+      <Box flexDirection="column">
+        <Text color="red">✗ Failed to request approval</Text>
+        <Text color="red">{error}</Text>
+        <Box
+          flexDirection="column"
+          borderStyle="round"
+          borderColor="cyan"
+          paddingX={2}
+          paddingY={1}
+          marginTop={1}
+        >
+          <Text>
+            Open:{' '}
+            <Text bold color="cyan">
+              {url}
+            </Text>
+          </Text>
+          <Text dimColor>Press Enter to open in browser</Text>
+          <Text dimColor>Exiting in {countdown}s...</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (status === 'opened') {
+    return (
+      <Box flexDirection="column">
+        <Text color="red">✗ Failed to request approval</Text>
+        <Text color="red">{error}</Text>
+        <Text color="green">✓ Opened verification URL in browser</Text>
+      </Box>
+    );
+  }
 
   if (status === 'requesting') {
     return (
@@ -94,16 +169,6 @@ export const RequestApproval: React.FC<RequestApprovalProps> = ({
       <Box flexDirection="column">
         <Text color="red">✗ Failed to request approval</Text>
         <Text color="red">{error}</Text>
-        {verificationUrl && (
-          <Text color="red">
-            Complete additional verification at: {verificationUrl}
-          </Text>
-        )}
-        {supportUrl && (
-          <Text color="red">
-            Identity verification failed. Contact support at: {supportUrl}
-          </Text>
-        )}
       </Box>
     );
   }


### PR DESCRIPTION
When spend-request create or spend-request request-approval fails with a step-up verification error (e.g. additional_verification_required, identity_verification_failed), previously, the URL was shown as a static error message and the CLI exited immediately. Now:
- The CLI displays the verification_url (or support_url) in a highlighted box with a "Press Enter to open in browser" prompt
- Pressing Enter opens the URL in the default browser and exits after a short delay
- If the user doesn't press Enter, the CLI auto-exits after a 30-second countdown
- The original error message is shown in both the prompt and post-open states

Before pressing enter to open the url:
<img width="1227" height="258" alt="Screenshot 2026-08-05 at 1 46 30 PM" src="https://github.com/user-attachments/assets/b29740b5-d32b-4318-a3cc-5bc6255d3c02" />

After pressing enter to have opened the url in the browser:
<img width="967" height="181" alt="Screenshot 2026-08-05 at 1 48 02 PM" src="https://github.com/user-attachments/assets/ba6006d7-5790-4dcb-a73e-ce6760634b92" />

No user action and exit in 30s:
<img width="1096" height="266" alt="Screenshot 2026-08-05 at 1 52 33 PM" src="https://github.com/user-attachments/assets/ed5fe8da-5a3c-4c91-ad5c-7958814c622b" />

