### PR TITLE
Update table styling for balances and sources commands

### DIFF
--- a/packages/cli/src/commands/balances/list.tsx
+++ b/packages/cli/src/commands/balances/list.tsx
@@ -19,6 +19,8 @@ interface BalancesListProps {
 const COLUMN_GAP = '  ';
 const SOURCE_ID_MIN = 16;
 const SOURCE_ID_MAX = 48;
+const NAME_MIN = 12;
+const NAME_MAX = 30;
 const TYPE_WIDTH = 12;
 const CURRENT_WIDTH = 15;
 const CURRENCY_WIDTH = 8;
@@ -51,6 +53,17 @@ function sourceIdWidth(balances: Balance[]): number {
   return Math.min(SOURCE_ID_MAX, Math.max(SOURCE_ID_MIN, maxLen));
 }
 
+function accountName(balance: Balance): string {
+  const name = balance.name;
+  return typeof name === 'string' && name.length > 0 ? name : '-';
+}
+
+function nameWidth(balances: Balance[]): number {
+  if (balances.length === 0) return NAME_MIN;
+  const maxLen = Math.max(...balances.map((b) => accountName(b).length));
+  return Math.min(NAME_MAX, Math.max(NAME_MIN, maxLen));
+}
+
 export const BalancesList: React.FC<BalancesListProps> = ({
   resource,
   params,
@@ -68,7 +81,9 @@ export const BalancesList: React.FC<BalancesListProps> = ({
       : null;
 
   const idWidth = sourceIdWidth(balances);
+  const accountNameWidth = nameWidth(balances);
   const headerRow = [
+    formatCell('Account name', accountNameWidth),
     formatCell('Source ID', idWidth),
     formatCell('Balance type', TYPE_WIDTH),
     formatCell('Current balance', CURRENT_WIDTH),
@@ -77,6 +92,7 @@ export const BalancesList: React.FC<BalancesListProps> = ({
   const separatorRow = '-'.repeat(headerRow.length);
   const rows = balances.map((balance) =>
     [
+      formatCell(accountName(balance), accountNameWidth),
       formatCell(balance.source_id ?? '-', idWidth),
       formatCell(balance.type ?? '-', TYPE_WIDTH),
       formatCell(

--- a/packages/cli/src/commands/balances/list.tsx
+++ b/packages/cli/src/commands/balances/list.tsx
@@ -83,7 +83,7 @@ export const BalancesList: React.FC<BalancesListProps> = ({
   const idWidth = sourceIdWidth(balances);
   const accountNameWidth = nameWidth(balances);
   const headerRow = [
-    formatCell('Account name', accountNameWidth),
+    formatCell('Source name', accountNameWidth),
     formatCell('Source ID', idWidth),
     formatCell('Balance type', TYPE_WIDTH),
     formatCell('Current balance', CURRENT_WIDTH),

--- a/packages/cli/src/commands/sources/__tests__/sources.test.tsx
+++ b/packages/cli/src/commands/sources/__tests__/sources.test.tsx
@@ -29,7 +29,7 @@ describe('sources list component', () => {
   });
 
   it('renders source details', async () => {
-    setTerminalWidth(160);
+    setTerminalWidth(200);
     const resource = makeResource({
       data: [
         {

--- a/packages/cli/src/commands/sources/list.tsx
+++ b/packages/cli/src/commands/sources/list.tsx
@@ -92,7 +92,7 @@ function sourceRow(source: Source, index: number): SourceRow {
 
   return {
     key: sourceId(source, index),
-    name: source.name ?? 'Source',
+    name: source.name ?? '-',
     type: source.type ?? '-',
     id: sourceId(source, index),
     capabilities,
@@ -102,7 +102,7 @@ function sourceRow(source: Source, index: number): SourceRow {
 
 function tableColumns(): TableColumn[] {
   return [
-    { label: 'Name', value: (row) => row.name, minWidth: 14, maxWidth: 24 },
+    { label: 'Name', value: (row) => row.name, minWidth: 14, maxWidth: 36 },
     { label: 'Type', value: (row) => row.type, minWidth: 10, maxWidth: 14 },
     { label: 'ID', value: (row) => row.id, minWidth: 16, maxWidth: 48 },
     {


### PR DESCRIPTION
* Adds an `Account name` column to the `balances list` table view
* Slightly adjusts max column widths for the `Name` in the `sources list` table view to better handle account names that can be quite long

<img width="773" height="72" alt="image" src="https://github.com/user-attachments/assets/6f5bcddd-793b-45d6-aa03-33c1bcc35429" />

<img width="947" height="69" alt="image" src="https://github.com/user-attachments/assets/29edc6ae-2d53-4a04-957d-5c5b5cc20a63" />
