### PR TITLE
fix: prevent [object Object] in API error messages

### DIFF
--- a/packages/cli/src/auth/__tests__/auth-resource.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-resource.test.ts
@@ -210,6 +210,24 @@ describe('LinkAuthResource', () => {
         LinkTransportError,
       );
     });
+
+    it('extracts message from nested error object instead of [object Object]', async () => {
+      mockFetchResponse(400, { error: { message: 'invalid scope: something' } });
+
+      const resource = createResource();
+      await expect(resource.initiateDeviceAuth()).rejects.toThrow(
+        'Device auth initiation failed (400): invalid scope: something',
+      );
+    });
+
+    it('preserves empty error_description rather than falling back to error code', async () => {
+      mockFetchResponse(400, { error: 'invalid_scope', error_description: '' });
+
+      const resource = createResource();
+      await expect(resource.initiateDeviceAuth()).rejects.toThrow(
+        'Device auth initiation failed (400): ',
+      );
+    });
   });
 
   describe('pollDeviceAuth', () => {
@@ -306,6 +324,22 @@ describe('LinkAuthResource', () => {
       await expect(resource.pollDeviceAuth('dev_123')).rejects.toThrow(
         /Token poll failed/,
       );
+    });
+
+    it('throws with readable message when 400 error is a nested object instead of [object Object]', async () => {
+      mockFetchResponse(400, { error: { message: 'invalid scope: something' } });
+
+      const resource = createResource();
+      await expect(resource.pollDeviceAuth('dev_123')).rejects.toThrow(
+        'Token poll failed (400): invalid scope: something',
+      );
+    });
+
+    it('still returns null for authorization_pending when error is a string', async () => {
+      mockFetchResponse(400, { error: 'authorization_pending' });
+
+      const resource = createResource();
+      expect(await resource.pollDeviceAuth('dev_123')).toBeNull();
     });
   });
 

--- a/packages/cli/src/auth/auth-resource.ts
+++ b/packages/cli/src/auth/auth-resource.ts
@@ -41,9 +41,24 @@ interface TokenResponse {
 }
 
 interface OAuthError {
-  error: string;
+  error: string | { message?: string };
   error_description?: string;
   scope_eligibility?: Record<string, ScopeEligibility>;
+}
+
+function extractOAuthErrorMessage(err: OAuthError | null): string | undefined {
+  if (!err) return undefined;
+  if (err.error_description != null) return err.error_description;
+  if (typeof err.error === 'string') return err.error;
+  if (typeof err.error === 'object' && err.error !== null) {
+    return err.error.message ?? JSON.stringify(err.error);
+  }
+  return undefined;
+}
+
+function extractOAuthErrorCode(err: OAuthError | null): string | undefined {
+  if (!err) return undefined;
+  return typeof err.error === 'string' ? err.error : undefined;
 }
 
 function formatOAuthError(
@@ -53,7 +68,7 @@ function formatOAuthError(
   rawBody: string,
 ): string {
   const err = data as OAuthError | null;
-  return `${prefix} (${status}): ${err?.error_description ?? err?.error ?? (rawBody || 'unknown error')}`;
+  return `${prefix} (${status}): ${extractOAuthErrorMessage(err) ?? (rawBody || 'unknown error')}`;
 }
 
 function appendAuthorizationDetailValue(
@@ -236,19 +251,19 @@ export class LinkAuthResource implements IAuthResource {
 
     if (status === 400) {
       const err = data as OAuthError;
-      switch (err.error) {
+      switch (extractOAuthErrorCode(err)) {
         case 'authorization_pending':
         case 'slow_down':
           return null;
         case 'expired_token':
           throw new LinkApiError(
             'Device code expired. Please restart the login flow.',
-            { status, code: err.error, rawBody, details: data },
+            { status, code: extractOAuthErrorCode(err), rawBody, details: data },
           );
         case 'access_denied':
           throw new LinkApiError('Authorization denied by user.', {
             status,
-            code: err.error,
+            code: extractOAuthErrorCode(err),
             rawBody,
             details: data,
           });
@@ -261,7 +276,7 @@ export class LinkAuthResource implements IAuthResource {
       formatOAuthError('Token poll failed', status, data, rawBody),
       {
         status,
-        code: (data as OAuthError | null)?.error,
+        code: extractOAuthErrorCode(data as OAuthError | null),
         rawBody,
         details: data,
       },
@@ -282,7 +297,7 @@ export class LinkAuthResource implements IAuthResource {
         formatOAuthError('Token revocation failed', status, data, rawBody),
         {
           status,
-          code: (data as OAuthError | null)?.error,
+          code: extractOAuthErrorCode(data as OAuthError | null),
           rawBody,
           details: data,
         },
@@ -305,7 +320,7 @@ export class LinkAuthResource implements IAuthResource {
         formatOAuthError('Token refresh failed', status, data, rawBody),
         {
           status,
-          code: (data as OAuthError | null)?.error,
+          code: extractOAuthErrorCode(data as OAuthError | null),
           rawBody,
           details: data,
         },

--- a/packages/cli/src/hooks/__tests__/use-async-action.test.tsx
+++ b/packages/cli/src/hooks/__tests__/use-async-action.test.tsx
@@ -1,0 +1,49 @@
+import { Text } from 'ink';
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAsyncAction } from '../use-async-action';
+
+function TestComponent({
+  action,
+  onComplete,
+}: {
+  action: () => Promise<unknown>;
+  onComplete: (result: unknown) => void;
+}) {
+  const { status, error } = useAsyncAction(action, onComplete);
+  if (status === 'error') return <Text>{error}</Text>;
+  return <Text>loading</Text>;
+}
+
+describe('useAsyncAction', () => {
+  it('surfaces Error message on failure', async () => {
+    const { lastFrame } = render(
+      <TestComponent
+        action={() => Promise.reject(new Error('something went wrong'))}
+        onComplete={() => {}}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(lastFrame()).toBe('something went wrong');
+    });
+  });
+
+  it('JSON-stringifies a thrown plain object instead of producing [object Object]', async () => {
+    const thrown = { code: 'NETWORK_ERROR', detail: 'timeout' };
+    const { lastFrame } = render(
+      <TestComponent
+        action={() => Promise.reject(thrown)}
+        onComplete={() => {}}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      const frame = lastFrame();
+      expect(frame).not.toBe('[object Object]');
+      expect(frame).toBe(JSON.stringify(thrown));
+    });
+  });
+
+});

--- a/packages/cli/src/hooks/use-async-action.ts
+++ b/packages/cli/src/hooks/use-async-action.ts
@@ -36,7 +36,7 @@ export function useAsyncAction<T>(
         );
       } catch (err) {
         if (cancelled) return;
-        const message = err instanceof Error ? err.message : String(err);
+        const message = err instanceof Error ? err.message : JSON.stringify(err);
         setError(message);
         setStatus('error');
         timeoutId = setTimeout(

--- a/packages/sdk/src/resources/__tests__/auth.test.ts
+++ b/packages/sdk/src/resources/__tests__/auth.test.ts
@@ -263,6 +263,22 @@ describe('AuthResource', () => {
         'Device auth initiation failed (500): server_error',
       );
     });
+
+    it('extracts message from nested error object instead of [object Object]', async () => {
+      mockFetchResponse(400, { error: { message: 'invalid scope: something' } });
+
+      await expect(repo.initiateDeviceAuth()).rejects.toThrow(
+        'Device auth initiation failed (400): invalid scope: something',
+      );
+    });
+
+    it('preserves empty error_description rather than falling back to error code', async () => {
+      mockFetchResponse(400, { error: 'invalid_scope', error_description: '' });
+
+      await expect(repo.initiateDeviceAuth()).rejects.toThrow(
+        'Device auth initiation failed (400): ',
+      );
+    });
   });
 
   describe('pollDeviceAuth', () => {
@@ -381,6 +397,21 @@ describe('AuthResource', () => {
       await expect(repo.pollDeviceAuth('dev_123')).rejects.toThrow(
         'Token poll failed (502): Bad Gateway',
       );
+    });
+
+    it('throws with readable message when 400 error is a nested object instead of [object Object]', async () => {
+      mockFetchResponse(400, { error: { message: 'invalid scope: something' } });
+
+      await expect(repo.pollDeviceAuth('dev_123')).rejects.toThrow(
+        'Token poll failed (400): invalid scope: something',
+      );
+    });
+
+    it('still returns null for authorization_pending when error is a string', async () => {
+      mockFetchResponse(400, { error: 'authorization_pending' });
+
+      const result = await repo.pollDeviceAuth('dev_123');
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/sdk/src/resources/__tests__/payment-methods.test.ts
+++ b/packages/sdk/src/resources/__tests__/payment-methods.test.ts
@@ -97,6 +97,14 @@ describe('PaymentMethodsResource', () => {
     );
   });
 
+  it('extracts message from nested error object instead of [object Object]', async () => {
+    mockFetchResponse(400, { error: { message: 'card not supported' } });
+
+    await expect(repo.listPaymentMethods()).rejects.toThrow(
+      'Failed to list payment methods (400): card not supported',
+    );
+  });
+
   it('throws when no access token is available', async () => {
     getAccessToken.mockRejectedValueOnce(new Error('Missing access token'));
 

--- a/packages/sdk/src/resources/__tests__/shipping-address.test.ts
+++ b/packages/sdk/src/resources/__tests__/shipping-address.test.ts
@@ -129,6 +129,14 @@ describe('ShippingAddressResource', () => {
     );
   });
 
+  it('extracts message from nested error object instead of [object Object]', async () => {
+    mockFetchResponse(400, { error: { message: 'address not supported' } });
+
+    await expect(repo.listShippingAddresses()).rejects.toThrow(
+      'Failed to list shipping addresses (400): address not supported',
+    );
+  });
+
   it('throws when no access token is available', async () => {
     getAccessToken.mockRejectedValueOnce(new Error('Missing access token'));
 

--- a/packages/sdk/src/resources/__tests__/user-info.test.ts
+++ b/packages/sdk/src/resources/__tests__/user-info.test.ts
@@ -145,4 +145,12 @@ describe('UserInfoResource', () => {
       'Failed to retrieve user info (403): Forbidden',
     );
   });
+
+  it('extracts message from nested error object instead of [object Object]', async () => {
+    mockFetchResponse(400, { error: { message: 'user not found' } });
+
+    await expect(resource.retrieve()).rejects.toThrow(
+      'Failed to retrieve user info (400): user not found',
+    );
+  });
 });

--- a/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
+++ b/packages/sdk/src/resources/__tests__/web-bot-auth.test.ts
@@ -142,6 +142,14 @@ describe('WebBotAuthResource', () => {
       expect(err.message).toMatch('Failed to get web bot auth headers (422)');
     });
 
+    it('extracts message from nested error object instead of [object Object]', async () => {
+      mockFetchResponse(400, { error: { message: 'signature failed' } });
+
+      const err = await resource.signUrl(validUrl).catch((e) => e);
+      expect(err).toBeInstanceOf(LinkApiError);
+      expect(err.message).toBe('Failed to get web bot auth headers (400): signature failed');
+    });
+
     it('throws LinkSdkError when expires_at is malformed', async () => {
       mockFetchResponse(200, {
         ...credentialsResponse,

--- a/packages/sdk/src/resources/auth.ts
+++ b/packages/sdk/src/resources/auth.ts
@@ -35,8 +35,23 @@ interface TokenResponse {
 }
 
 interface OAuthError {
-  error: string;
+  error: string | { message?: string };
   error_description?: string;
+}
+
+function extractOAuthErrorMessage(err: OAuthError | null): string | undefined {
+  if (!err) return undefined;
+  if (err.error_description != null) return err.error_description;
+  if (typeof err.error === 'string') return err.error;
+  if (typeof err.error === 'object' && err.error !== null) {
+    return err.error.message ?? JSON.stringify(err.error);
+  }
+  return undefined;
+}
+
+function extractOAuthErrorCode(err: OAuthError | null): string | undefined {
+  if (!err) return undefined;
+  return typeof err.error === 'string' ? err.error : undefined;
 }
 
 function formatOAuthError(
@@ -46,7 +61,7 @@ function formatOAuthError(
   rawBody: string,
 ): string {
   const err = data as OAuthError | null;
-  return `${prefix} (${status}): ${err?.error_description ?? err?.error ?? (rawBody || 'unknown error')}`;
+  return `${prefix} (${status}): ${extractOAuthErrorMessage(err) ?? (rawBody || 'unknown error')}`;
 }
 
 function dedupe<T>(values: readonly T[]): T[] {
@@ -263,19 +278,19 @@ export class AuthResource implements IAuthResource {
 
     if (status === 400) {
       const err = data as OAuthError;
-      switch (err.error) {
+      switch (extractOAuthErrorCode(err)) {
         case 'authorization_pending':
         case 'slow_down':
           return null;
         case 'expired_token':
           throw new LinkApiError(
             'Device code expired. Please restart the login flow.',
-            { status, code: err.error, rawBody, details: data },
+            { status, code: extractOAuthErrorCode(err), rawBody, details: data },
           );
         case 'access_denied':
           throw new LinkApiError('Authorization denied by user.', {
             status,
-            code: err.error,
+            code: extractOAuthErrorCode(err),
             rawBody,
             details: data,
           });
@@ -286,7 +301,7 @@ export class AuthResource implements IAuthResource {
       formatOAuthError('Token poll failed', status, data, rawBody),
       {
         status,
-        code: (data as OAuthError | null)?.error,
+        code: extractOAuthErrorCode(data as OAuthError | null),
         rawBody,
         details: data,
       },
@@ -307,7 +322,7 @@ export class AuthResource implements IAuthResource {
         formatOAuthError('Token revocation failed', status, data, rawBody),
         {
           status,
-          code: (data as OAuthError | null)?.error,
+          code: extractOAuthErrorCode(data as OAuthError | null),
           rawBody,
           details: data,
         },
@@ -330,7 +345,7 @@ export class AuthResource implements IAuthResource {
         formatOAuthError('Token refresh failed', status, data, rawBody),
         {
           status,
-          code: (data as OAuthError | null)?.error,
+          code: extractOAuthErrorCode(data as OAuthError | null),
           rawBody,
           details: data,
         },

--- a/packages/sdk/src/resources/payment-methods.ts
+++ b/packages/sdk/src/resources/payment-methods.ts
@@ -4,6 +4,7 @@ import {
   resolveLinkSdkConfig,
 } from '@/config';
 import { LinkApiError, LinkTransportError } from '@/errors';
+import { extractErrorMessage } from '@/resources/base';
 import type {
   AccessTokenProvider,
   IPaymentMethodsResource,
@@ -108,13 +109,8 @@ export class PaymentMethodsResource implements IPaymentMethodsResource {
     });
 
     if (status < 200 || status >= 300) {
-      const body = data as Record<string, unknown> | null;
-      const msg =
-        (body?.error as string | undefined) ??
-        (body?.message as string | undefined) ??
-        (rawBody || 'unknown error');
       throw new LinkApiError(
-        `Failed to list payment methods (${status}): ${msg}`,
+        `Failed to list payment methods (${status}): ${extractErrorMessage(data, rawBody)}`,
         { status, rawBody, details: data },
       );
     }

--- a/packages/sdk/src/resources/shipping-address.ts
+++ b/packages/sdk/src/resources/shipping-address.ts
@@ -4,6 +4,7 @@ import {
   resolveLinkSdkConfig,
 } from '@/config';
 import { LinkApiError, LinkTransportError } from '@/errors';
+import { extractErrorMessage } from '@/resources/base';
 import type {
   AccessTokenProvider,
   IShippingAddressResource,
@@ -108,13 +109,8 @@ export class ShippingAddressResource implements IShippingAddressResource {
     });
 
     if (status < 200 || status >= 300) {
-      const body = data as Record<string, unknown> | null;
-      const msg =
-        (body?.error as string | undefined) ??
-        (body?.message as string | undefined) ??
-        (rawBody || 'unknown error');
       throw new LinkApiError(
-        `Failed to list shipping addresses (${status}): ${msg}`,
+        `Failed to list shipping addresses (${status}): ${extractErrorMessage(data, rawBody)}`,
         { status, rawBody, details: data },
       );
     }

--- a/packages/sdk/src/resources/user-info.ts
+++ b/packages/sdk/src/resources/user-info.ts
@@ -4,6 +4,7 @@ import {
   resolveLinkSdkConfig,
 } from '@/config';
 import { LinkApiError, LinkTransportError } from '@/errors';
+import { extractErrorMessage } from '@/resources/base';
 import type {
   AccessTokenProvider,
   IUserInfoResource,
@@ -104,18 +105,9 @@ export class UserInfoResource implements IUserInfoResource {
     });
 
     if (status < 200 || status >= 300) {
-      const body = data as Record<string, unknown> | null;
-      const msg =
-        (body?.error as string | undefined) ??
-        (body?.message as string | undefined) ??
-        (rawBody || 'unknown error');
       throw new LinkApiError(
-        `Failed to retrieve user info (${status}): ${msg}`,
-        {
-          status,
-          rawBody,
-          details: data,
-        },
+        `Failed to retrieve user info (${status}): ${extractErrorMessage(data, rawBody)}`,
+        { status, rawBody, details: data },
       );
     }
 

--- a/packages/sdk/src/resources/web-bot-auth.ts
+++ b/packages/sdk/src/resources/web-bot-auth.ts
@@ -4,6 +4,7 @@ import {
   resolveLinkSdkConfig,
 } from '@/config';
 import { LinkApiError, LinkSdkError, LinkTransportError } from '@/errors';
+import { extractErrorMessage } from '@/resources/base';
 import type {
   AccessTokenProvider,
   IWebBotAuthResource,
@@ -154,13 +155,8 @@ export class WebBotAuthResource implements IWebBotAuthResource {
     });
 
     if (status < 200 || status >= 300) {
-      const body = data as Record<string, unknown> | null;
-      const msg =
-        (body?.error as string | undefined) ??
-        (body?.message as string | undefined) ??
-        (rawBody || 'unknown error');
       throw new LinkApiError(
-        `Failed to get web bot auth headers (${status}): ${msg}`,
+        `Failed to get web bot auth headers (${status}): ${extractErrorMessage(data, rawBody)}`,
         { status, rawBody, details: data },
       );
     }


### PR DESCRIPTION

##  Problem

  When the API returns an error in the nested object shape { "error": { "message": "invalid scope: something" } }, several places in the codebase would coerce that object directly into a string — producing [object Object] in the terminal instead of the actual error message.

1 Example: 

Before:

<img width="442" height="121" alt="632436803-9198e1fd-1a4a-4ad5-9acc-2586697d6bd9" src="https://github.com/user-attachments/assets/3d969abd-4f07-4db8-9f49-c05706d4b99b" />


After: 

<img width="834" height="78" alt="CleanShot 2026-08-06 at 16 16 22" src="https://github.com/user-attachments/assets/a6019b2d-955d-4cb7-b96e-784009675d1c" />


## Root causes fixed

  1. Auth resources (CLI + SDK) — formatOAuthError interpolated err.error directly. Since err.error can be an object, this produced [object Object]. Fixed by adding extractOAuthErrorMessage which checks typeof err.error at runtime before extracting
  the message.
  2. pollDeviceAuth switch bug — switch (err.error) was comparing a string | object union against string case labels. When error was an object, authorization_pending and slow_down never matched, causing the polling loop to throw instead of
  continuing. Fixed by switching on extractOAuthErrorCode(err) (returns string | undefined).
  3. error_description regression — The new extractOAuthErrorMessage used a truthy check (if (err.error_description)) instead of nullish (!= null), silently dropping an empty-string description and falling back to the error code instead. Fixed to
  match the prior ?? behavior.
  4. Four SDK resources — payment-methods, shipping-address, user-info, and web-bot-auth extracted errors with (body?.error as string | undefined) ?? — a TypeScript-only cast with no runtime guard. A nested object error passed the ?? check and got
  coerced. Fixed by replacing the inline pattern with extractErrorMessage(data, rawBody) from base.ts, which already handles both shapes correctly.
  5. useAsyncAction hook — String(err) for non-Error throwables produces [object Object] for plain objects. Fixed to JSON.stringify(err).