### PR TITLE
feat: Handle duplicate spend request rate limit response

### DIFF
--- a/.changeset/rare-numbers-invent.md
+++ b/.changeset/rare-numbers-invent.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": minor
+---
+
+Surface duplicate spend request error messaging in interactive mode

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -565,6 +565,44 @@ describe('production mode', () => {
       const output = result.stdout + result.stderr;
       expect(output).toContain('Invalid payment details');
     });
+
+    it('surfaces the duplicate spend request on spend_request_rate_limited error', async () => {
+      setNextResponse(429, {
+        error: {
+          code: 'spend_request_rate_limited',
+          message:
+            'You cannot submit duplicate spend requests within a short period of time. Please try again later.',
+          retry_after: 1699999999,
+          duplicate_spend_request: {
+            ...BASE_REQUEST,
+            id: 'lsrq_duplicate',
+            status: 'created',
+          },
+        },
+      });
+
+      const result = await runProdCli(
+        'spend-request',
+        'create',
+        '--payment-method-id',
+        'pd_prod_test',
+        '-m',
+        'Test Merchant',
+        '--merchant-url',
+        'https://example.com',
+        '--context',
+        VALID_CONTEXT,
+        '--amount',
+        '5000',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(1);
+      const output = parseJson(result.stdout) as Record<string, unknown>;
+      expect(output.code).toBe('spend_request_rate_limited');
+      expect(String(output.message)).toContain('lsrq_duplicate');
+      expect(String(output.message)).toContain('created');
+    });
   });
 
   describe('spend-request update', () => {

--- a/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
+++ b/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
@@ -151,6 +151,72 @@ describe('spend-request', () => {
       });
     });
 
+    it('CreateSpendRequest surfaces the duplicate spend request on spend_request_rate_limited error', async () => {
+      const error = new LinkApiError(
+        'Failed to create spend request (429): You cannot submit duplicate spend requests within a short period of time.',
+        {
+          status: 429,
+          code: 'api_error',
+          details: {
+            error: {
+              code: 'spend_request_rate_limited',
+              message:
+                'You cannot submit duplicate spend requests within a short period of time.',
+              retry_after: 1699999999,
+              duplicate_spend_request: {
+                id: 'sr_duplicate',
+                status: 'created',
+                amount: 5000,
+                currency: 'usd',
+                merchant_name: ESCAPE_PAYLOAD,
+                context: 'x'.repeat(100),
+                payment_details: 'pm_1',
+                line_items: [],
+                totals: [],
+                created_at: '2025-01-01T00:00:00Z',
+                updated_at: '2025-01-01T00:00:00Z',
+              },
+            },
+          },
+        },
+      );
+      const repo = sanitizeResource({
+        createSpendRequest: vi.fn(async () => {
+          throw error;
+        }),
+        getSpendRequest: vi.fn(),
+        updateSpendRequest: vi.fn(),
+        requestApproval: vi.fn(),
+        cancelSpendRequest: vi.fn(),
+      } as unknown as ISpendRequestResource);
+
+      const { lastFrame } = render(
+        <CreateSpendRequest
+          repository={repo}
+          params={{
+            payment_details: 'pm_1',
+            amount: 5000,
+            currency: 'usd',
+            merchant_name: 'Stripe Press',
+            merchant_url: 'https://press.stripe.com',
+            context: 'x'.repeat(100),
+          }}
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Failed to create spend request');
+        expect(frame).toContain('A matching spend request already exists');
+        expect(frame).toContain('sr_duplicate');
+        expect(frame).toContain('spend-request retrieve sr_duplicate');
+        // Duplicate fields are sanitized before rendering.
+        expect(frame).toContain(CLEAN_TEXT);
+        expect(frame).not.toContain('\x1b[2J');
+      });
+    });
+
     it('RequestApproval surfaces verification_url on additional_verification_required error', async () => {
       const error = new LinkApiError(
         'Consumer must complete additional verification before creating spend requests.',

--- a/packages/cli/src/commands/spend-request/create.tsx
+++ b/packages/cli/src/commands/spend-request/create.tsx
@@ -3,7 +3,7 @@ import type {
   ISpendRequestResource,
   SpendRequest,
 } from '@stripe/link-sdk';
-import { LinkApiError } from '@stripe/link-sdk';
+import { LinkApiError, getDuplicateSpendRequest } from '@stripe/link-sdk';
 import { Box, Text, useApp, useInput } from 'ink';
 import Spinner from 'ink-spinner';
 import type React from 'react';
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { DISPLAY_DELAY_MS } from '../../utils/constants';
 import { writeCredentialFile } from '../../utils/credential-output';
 import { openUrl } from '../../utils/open-url';
+import { sanitizeDeep } from '../../utils/sanitize-text';
 import { AppDownloadQrCodes } from './app-download-qr-codes';
 import { ApprovalWaitingView } from './approval-waiting-view';
 import { useApprovalPolling } from './use-approval-polling';
@@ -44,6 +45,9 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
     | 'opened'
   >('creating');
   const [request, setRequest] = useState<SpendRequest | null>(null);
+  const [duplicateRequest, setDuplicateRequest] = useState<SpendRequest | null>(
+    null,
+  );
   const [error, setError] = useState<string>('');
   const [verificationUrl, setVerificationUrl] = useState<string>('');
   const [supportUrl, setSupportUrl] = useState<string>('');
@@ -129,6 +133,8 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
             setStatus('verification_required');
             return;
           }
+          const duplicate = getDuplicateSpendRequest(err);
+          if (duplicate) setDuplicateRequest(sanitizeDeep(duplicate));
         }
         setStatus('error');
         setTimeout(() => completeAndExit(null), DISPLAY_DELAY_MS);
@@ -206,6 +212,45 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
       <Box flexDirection="column">
         <Text color="red">✗ Failed to create spend request</Text>
         <Text color="red">{error}</Text>
+        {duplicateRequest && (
+          <Box
+            flexDirection="column"
+            borderStyle="round"
+            borderColor="yellow"
+            paddingX={2}
+            paddingY={1}
+            marginTop={1}
+          >
+            <Text bold color="yellow">
+              A matching spend request already exists
+            </Text>
+            <Box flexDirection="column" marginTop={1}>
+              <Text>
+                ID: <Text bold>{duplicateRequest.id}</Text>
+              </Text>
+              <Text>
+                Status: <Text bold>{duplicateRequest.status}</Text>
+              </Text>
+              <Text>
+                Amount:{' '}
+                <Text bold>
+                  {duplicateRequest.amount != null
+                    ? `${duplicateRequest.amount} ${duplicateRequest.currency?.toUpperCase() ?? ''}`.trim()
+                    : 'N/A'}
+                </Text>
+              </Text>
+              <Text>
+                Merchant: <Text bold>{duplicateRequest.merchant_name}</Text>
+              </Text>
+            </Box>
+            <Text dimColor>
+              {'\n'}Retrieve it to resume instead of creating a new one:
+            </Text>
+            <Text color="cyan">
+              spend-request retrieve {duplicateRequest.id}
+            </Text>
+          </Box>
+        )}
       </Box>
     );
   }

--- a/packages/cli/src/commands/spend-request/create.tsx
+++ b/packages/cli/src/commands/spend-request/create.tsx
@@ -247,9 +247,9 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
                 Merchant: <Text bold>{duplicateRequest.merchant_name}</Text>
               </Text>
             </Box>
-            {duplicateRequest.status != 'expired' &&
-              duplicateRequest.status != 'canceled' &&
-              duplicateRequest.status != 'failed' && (
+            {duplicateRequest.status !== 'expired' &&
+              duplicateRequest.status !== 'canceled' &&
+              duplicateRequest.status !== 'failed' && (
                 <>
                   <Text dimColor>
                     {'\n'}Retrieve it to resume instead of creating a new one:

--- a/packages/cli/src/commands/spend-request/create.tsx
+++ b/packages/cli/src/commands/spend-request/create.tsx
@@ -10,6 +10,7 @@ import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
 import { DISPLAY_DELAY_MS } from '../../utils/constants';
 import { writeCredentialFile } from '../../utils/credential-output';
+import { formatAmount } from '../../utils/format-amount';
 import { openUrl } from '../../utils/open-url';
 import { sanitizeDeep } from '../../utils/sanitize-text';
 import { AppDownloadQrCodes } from './app-download-qr-codes';
@@ -235,7 +236,10 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
                 Amount:{' '}
                 <Text bold>
                   {duplicateRequest.amount != null
-                    ? `${duplicateRequest.amount} ${duplicateRequest.currency?.toUpperCase() ?? ''}`.trim()
+                    ? formatAmount(
+                        duplicateRequest.amount,
+                        duplicateRequest.currency ?? '',
+                      )
                     : 'N/A'}
                 </Text>
               </Text>
@@ -243,12 +247,18 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
                 Merchant: <Text bold>{duplicateRequest.merchant_name}</Text>
               </Text>
             </Box>
-            <Text dimColor>
-              {'\n'}Retrieve it to resume instead of creating a new one:
-            </Text>
-            <Text color="cyan">
-              spend-request retrieve {duplicateRequest.id}
-            </Text>
+            {duplicateRequest.status != 'expired' &&
+              duplicateRequest.status != 'canceled' &&
+              duplicateRequest.status != 'failed' && (
+                <>
+                  <Text dimColor>
+                    {'\n'}Retrieve it to resume instead of creating a new one:
+                  </Text>
+                  <Text color="cyan">
+                    spend-request retrieve {duplicateRequest.id}
+                  </Text>
+                </>
+              )}
           </Box>
         )}
       </Box>
@@ -270,7 +280,7 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
             Amount:{' '}
             <Text bold>
               {request?.amount != null
-                ? `${request.amount} ${request.currency?.toUpperCase() ?? ''}`.trim()
+                ? formatAmount(request.amount, request.currency ?? '')
                 : 'N/A'}
             </Text>
           </Text>

--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -1,4 +1,4 @@
-import { LinkApiError } from '@stripe/link-sdk';
+import { LinkApiError, getDuplicateSpendRequest } from '@stripe/link-sdk';
 import type {
   AuthStorage,
   CredentialType,
@@ -237,6 +237,24 @@ export function createSpendRequestCli(
             return c.error({
               code: err.code,
               message: `${err.message} Support URL: ${apiErr.error.support_url}`,
+            });
+          }
+          const duplicate = getDuplicateSpendRequest(err);
+          if (duplicate) {
+            return c.error({
+              code: apiErr?.error?.code ?? 'spend_request_rate_limited',
+              message: `${err.message} A matching spend request already exists: ${duplicate.id} (status: ${duplicate.status}). Retrieve it to resume instead of creating a new one.`,
+              cta: {
+                description:
+                  'Retrieve the conflicting spend request to inspect its status and resume it if valid.',
+                commands: [
+                  {
+                    command: `spend-request retrieve ${duplicate.id}`,
+                    description:
+                      'Retrieve the conflicting spend request to resume it',
+                  },
+                ],
+              },
             });
           }
         }

--- a/packages/cli/src/commands/transactions/list.tsx
+++ b/packages/cli/src/commands/transactions/list.tsx
@@ -8,6 +8,7 @@ import Spinner from 'ink-spinner';
 import type React from 'react';
 import { useCallback } from 'react';
 import { useAsyncAction } from '../../hooks/use-async-action';
+import { formatAmount } from '../../utils/format-amount';
 
 interface TransactionsListProps {
   resource: ITransactionsResource;
@@ -22,22 +23,6 @@ const STATUS_WIDTH = 10;
 const CATEGORY_WIDTH = 16;
 const MIN_DESCRIPTION_WIDTH = 16;
 const HORIZONTAL_PADDING = 4;
-
-function formatAmount(amount: number, currency: string): string {
-  const currencyCode = currency.toUpperCase();
-
-  try {
-    const formatter = new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: currencyCode,
-    });
-    const fractionDigits =
-      formatter.resolvedOptions().maximumFractionDigits ?? 2;
-    return formatter.format(amount / 10 ** fractionDigits);
-  } catch {
-    return `${amount} ${currency}`;
-  }
-}
 
 function truncateCell(value: string, width: number): string {
   if (value.length <= width) {

--- a/packages/cli/src/utils/format-amount.ts
+++ b/packages/cli/src/utils/format-amount.ts
@@ -1,0 +1,21 @@
+/**
+ * Format a minor-unit amount (e.g. cents) into a human-readable major-unit
+ * currency string. For example, 5 with currency "usd" becomes "$0.05".
+ *
+ * Falls back to `${amount} ${currency}` for unknown currency codes.
+ */
+export function formatAmount(amount: number, currency: string): string {
+  const currencyCode = currency.toUpperCase();
+
+  try {
+    const formatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currencyCode,
+    });
+    const fractionDigits =
+      formatter.resolvedOptions().maximumFractionDigits ?? 2;
+    return formatter.format(amount / 10 ** fractionDigits);
+  } catch {
+    return `${amount} ${currency}`;
+  }
+}

--- a/packages/sdk/src/resources/__tests__/spend-request.test.ts
+++ b/packages/sdk/src/resources/__tests__/spend-request.test.ts
@@ -1,5 +1,9 @@
+import { LinkApiError } from '@/errors';
 import type { CreateSpendRequestParams } from '@/resources/interfaces';
-import { SpendRequestResource } from '@/resources/spend-request';
+import {
+  SpendRequestResource,
+  getDuplicateSpendRequest,
+} from '@/resources/spend-request';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockFetch = vi.fn();
@@ -530,5 +534,73 @@ describe('SpendRequestResource', () => {
         'Missing access token',
       );
     });
+  });
+});
+
+describe('getDuplicateSpendRequest', () => {
+  const duplicate = {
+    id: 'si_duplicate',
+    status: 'created',
+    amount: 5000,
+    currency: 'usd',
+    merchant_name: 'Test Store',
+    context: 'buying a widget',
+    payment_details: 'pd_test123',
+    line_items: [],
+    totals: [],
+    created_at: '2026-03-10T00:00:00Z',
+    updated_at: '2026-03-10T00:00:00Z',
+  };
+
+  it('extracts the duplicate spend request from a rate-limited error', () => {
+    const err = new LinkApiError('Failed to create spend request (429): ...', {
+      status: 429,
+      details: {
+        error: {
+          code: 'spend_request_rate_limited',
+          message: 'You cannot submit duplicate spend requests...',
+          retry_after: 1699999999,
+          duplicate_spend_request: duplicate,
+        },
+      },
+    });
+
+    expect(getDuplicateSpendRequest(err)).toEqual(duplicate);
+  });
+
+  it('normalizes a legacy string shared_payment_token on the duplicate', () => {
+    const err = new LinkApiError('Failed to create spend request (429): ...', {
+      status: 429,
+      details: {
+        error: {
+          code: 'spend_request_rate_limited',
+          duplicate_spend_request: {
+            ...duplicate,
+            credential_type: 'shared_payment_token',
+            shared_payment_token: 'spt_legacy',
+          },
+        },
+      },
+    });
+
+    expect(getDuplicateSpendRequest(err)?.shared_payment_token).toEqual({
+      id: 'spt_legacy',
+    });
+  });
+
+  it('returns null when the error carries no duplicate', () => {
+    const err = new LinkApiError('Failed to create spend request (429): ...', {
+      status: 429,
+      details: {
+        error: { code: 'spend_request_rate_limited', retry_after: 123 },
+      },
+    });
+
+    expect(getDuplicateSpendRequest(err)).toBeNull();
+  });
+
+  it('returns null for a non-LinkApiError', () => {
+    expect(getDuplicateSpendRequest(new Error('boom'))).toBeNull();
+    expect(getDuplicateSpendRequest(undefined)).toBeNull();
   });
 });

--- a/packages/sdk/src/resources/spend-request.ts
+++ b/packages/sdk/src/resources/spend-request.ts
@@ -38,6 +38,23 @@ function normalizeSpendRequest(data: unknown): SpendRequest {
   return sr;
 }
 
+/**
+ * Extracts the conflicting spend request returned alongside a
+ * `spend_request_rate_limited` (429) error. The API includes
+ * `error.duplicate_spend_request` only when the caller is on the same
+ * connection as the blocking request. Returns `null` for any other error or
+ * when no duplicate is present.
+ */
+export function getDuplicateSpendRequest(error: unknown): SpendRequest | null {
+  if (!(error instanceof LinkApiError)) return null;
+  const details = error.details as
+    | { error?: { duplicate_spend_request?: unknown } }
+    | undefined;
+  const duplicate = details?.error?.duplicate_spend_request;
+  if (!duplicate || typeof duplicate !== 'object') return null;
+  return normalizeSpendRequest(duplicate);
+}
+
 function extractApiError(data: unknown, rawBody: string): string {
   if (data && typeof data === 'object') {
     const body = data as Record<string, unknown>;

--- a/packages/sdk/src/resources/spend-request.ts
+++ b/packages/sdk/src/resources/spend-request.ts
@@ -40,10 +40,7 @@ function normalizeSpendRequest(data: unknown): SpendRequest {
 
 /**
  * Extracts the conflicting spend request returned alongside a
- * `spend_request_rate_limited` (429) error. The API includes
- * `error.duplicate_spend_request` only when the caller is on the same
- * connection as the blocking request. Returns `null` for any other error or
- * when no duplicate is present.
+ * `spend_request_rate_limited` (429) error.
  */
 export function getDuplicateSpendRequest(error: unknown): SpendRequest | null {
   if (!(error instanceof LinkApiError)) return null;


### PR DESCRIPTION
Updates the CLI to handle the error response to handle the new `duplicate_spend_request` field when the SpendRequest was rate-limited via fingerprinting/duplicate checks.

**When SpendRequest is resumable:**
<img width="1430" height="308" alt="Screenshot 2026-08-13 at 10 36 48 AM" src="https://github.com/user-attachments/assets/72bf4741-8cf3-469e-bcef-6b2c8e6aa524" />


**When SpendRequest is not resumable:**
<img width="1430" height="372" alt="Screenshot 2026-08-13 at 10 37 13 AM" src="https://github.com/user-attachments/assets/a56d0c94-1238-4ea7-aeb6-b5cfa70e5ca9" />

**JSON formatting:**
<img width="1430" height="99" alt="Screenshot 2026-08-13 at 10 35 15 AM" src="https://github.com/user-attachments/assets/55d78e28-5cd9-4479-a5e6-4cfd07542198" />
