### PR TITLE
Add changelog entry for financial insights command and skill file changes

### DIFF
--- a/.changeset/lucky-planets-gather.md
+++ b/.changeset/lucky-planets-gather.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": minor
+---
+
+Expose the financial insights commands (`balances`, `sources`, `transactions`) in the CLI's command list and ship the `financial-insights` skill file


### PR DESCRIPTION
Adds a changelog entry for financial insights command and skill file changes, in preparation for the next version release. This is a follow up to https://github.com/stripe/link-cli/pull/240