### PR TITLE
Updates the published limits to $500

### DIFF
--- a/.changeset/spotty-mice-jog.md
+++ b/.changeset/spotty-mice-jog.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": patch
+---
+
+clarify correct daily limits

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Link Pay Token requests require `execution_method=link_pay_token` and the
 DOM-derived `merchant_account_id`, and Link supplies their canonical merchant
 identity.
 
-**Constraints:** `context` must be at least 100 characters; `amount` must not exceed 500000 (cents); `currency` must be a 3-letter ISO code. The user has 10 minutes from when approval is requested to approve. Approved credentials (card or SPT) are valid for 12 hours from spend request creation.
+**Constraints:** `context` must be at least 100 characters; `amount` must not exceed 50000 (cents); `currency` must be a 3-letter ISO code. The user has 10 minutes from when approval is requested to approve. Approved credentials (card or SPT) are valid for 12 hours from spend request creation.
 **Test mode:** Pass `--test` to create a testmode SpendRequest. A testmode SpendRequest will return test payment credentials (e.g test card `4000009990001984`) rather than a real payment credential. Testmode SpendRequests will not charge the underlying payment method of the SpendRequest. This is useful for development and integration testing without real payment methods.
 
 ```bash
@@ -309,10 +309,10 @@ link-cli spend-request cancel lsrq_001
 
 | Limit | Value |
 |-------|-------|
-| Max amount per spend request | $5,000 (500,000 cents) |
+| Max amount per spend request | $500 (50,000 cents) |
 | Approval window | 10 minutes — user must approve within 10 min of `request-approval` |
 | Card / SPT validity | 12 hours from spend request creation |
-| Daily spend | $5,000 |
+| Daily spend | $500 |
 | Monthly spend (30 days) | $20,000 |
 | Concurrent active requests (created + approved) | 30 |
 | Concurrent approved requests | 10 |

--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -31,7 +31,7 @@ export const createOptions = z.object({
     .int()
     .positive()
     .max(500000)
-    .describe('Amount in cents, max 500000 ($5,000.00)'),
+    .describe('Amount in cents'),
   currency: z.string().length(3).default('usd').describe('Currency code'),
   merchantName: z
     .string()

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -324,10 +324,10 @@ report `blocked`. Do not reuse the LPT at a different checkout surface.
 
 | Limit | Value |
 |-------|-------|
-| Max amount per spend request | $5,000 (500,000 cents) |
+| Max amount per spend request | $500 (50,000 cents) |
 | Approval window | 10 minutes — user must approve within 10 min of `spend-request request-approval` |
 | Card / SPT validity (`valid_until`) | 12 hours from spend request creation |
-| Daily spend per account | $5,000 |
+| Daily spend per account | $500 |
 | Monthly spend per account (30 days) | $20,000 |
 | Concurrent active requests (created + approved) | 30 |
 | Concurrent approved requests | 10 |


### PR DESCRIPTION
Corrects the docs that the daily limit for spend requests is $500