### PR TITLE
fix: align spend request amount cap with the published $500 limit

### DIFF
--- a/.changeset/tidy-moons-repeat.md
+++ b/.changeset/tidy-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": patch
+---
+
+Enforce the published $500 (50,000 cents) per-spend-request limit in the create schema

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ CLI command is `spend-request` (user-facing). Implemented in `packages/cli/src/c
 Key input field notes:
 - CLI input uses `payment_method_id`; mapped to `payment_details` when calling the SDK
 - `--execution-method link_pay_token` and `--merchant-account-id acct_...` are a create-only pair for Link Pay Token checkout. The agent reads the account ID from `data-stripe-merchant-account` in the AI-agent steering DOM before creating the request; Link resolves the canonical merchant identity. LPT uses `credential_type: card`, cannot use `--test` or `--network-id`, and must not accept agent-provided merchant name or URL. Never add the target fields to the update path.
-- `context` requires min 100 characters; `amount` is in cents with max 500000
+- `context` requires min 100 characters; `amount` is in cents with max 50000
 - `--metadata` (create only) is a repeatable `key:value` flag (CLI) or a `{ key: value }` object (MCP/agent), merged into a single `metadata` string→string map. Max 50 keys, key ≤ 40 chars, value ≤ 500 chars. Reuses `parseKvString` from `line-item-parser.ts`.
 - `--test` flag creates testmode credentials (real testmode SPT from test card data) instead of livemode ones
 - `create --request-approval` and `request-approval` both show an approval URL in interactive mode and poll until approved/denied/expired/failed/canceled. In JSON mode (`--format json`), they return immediately with an `_next.command` for `spend-request retrieve`.

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -764,6 +764,28 @@ describe('production mode', () => {
       expect(output).toContain('Invalid payment details');
     });
 
+    it('rejects an amount above the published per-request limit', async () => {
+      const result = await runProdCli(
+        'spend-request',
+        'create',
+        '--payment-method-id',
+        'pd_prod_test',
+        '-m',
+        'Test Merchant',
+        '--merchant-url',
+        'https://example.com',
+        '--context',
+        VALID_CONTEXT,
+        '--amount',
+        '60000',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(1);
+      const output = result.stdout + result.stderr;
+      expect(output).toMatch(/amount|50000/i);
+    });
+
     it('surfaces the duplicate spend request on spend_request_rate_limited error', async () => {
       setNextResponse(429, {
         error: {

--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -30,8 +30,8 @@ export const createOptions = z.object({
     .number()
     .int()
     .positive()
-    .max(500000)
-    .describe('Amount in cents'),
+    .max(50000)
+    .describe('Amount in cents, max 50000 ($500.00)'),
   currency: z.string().length(3).default('usd').describe('Currency code'),
   merchantName: z
     .string()


### PR DESCRIPTION
## Problem

#251 lowered the published per-request maximum to 50,000 cents. The client still accepts 500,000.

| Source | Value |
|---|---|
| `README.md:290` | 50,000 |
| `skills/create-payment-credential/SKILL.md:326` | 50,000 |
| `CLAUDE.md:80` | 500,000 |
| `schema.ts:33` | 500,000 |

`spend-request create --amount 400000` passes local validation today and fails at the API instead. Catching it locally is what the schema is for. #251 also dropped the number from the `.describe()` string, so `--schema` output no longer states any limit at all.

CLAUDE.md asks for README, SKILL.md, the schema description and CLAUDE.md to move together. This brings along the two that were left behind.

## Change

- `createOptions.amount` max 500000 to 50000
- restore the limit in the flag description
- fix the CLAUDE.md line
- one test for the rejection

If the per-request maximum is still $5,000 and only the daily limit moved to $500, say so and I will flip this into a docs revert instead.
