### PR TITLE
Fix: allow shipping address nickname to be optional in resource

### DIFF
--- a/.changeset/major-sites-search.md
+++ b/.changeset/major-sites-search.md
@@ -1,0 +1,6 @@
+---
+"@stripe/link-sdk": patch
+"@stripe/link-cli": patch
+---
+
+Fix: allow nickname to be undefined in shipping address resource

--- a/packages/sdk/src/resources/shipping-address.ts
+++ b/packages/sdk/src/resources/shipping-address.ts
@@ -7,7 +7,7 @@ import { z } from 'zod';
 const shippingAddressSchema = z.looseObject({
   id: z.string(),
   is_default: z.boolean(),
-  nickname: z.string().nullable(),
+  nickname: z.optional(z.string().nullable()),
   address: z.looseObject({}).nullable(),
 });
 const shippingAddressesResponseSchema = z.looseObject({

--- a/plugins/cursor-link/.cursor-plugin/plugin.json
+++ b/plugins/cursor-link/.cursor-plugin/plugin.json
@@ -10,13 +10,7 @@
   "repository": "https://github.com/stripe/link-cli",
   "license": "MIT",
   "logo": "./assets/link.svg",
-  "keywords": [
-    "payment",
-    "link",
-    "stripe",
-    "agentic-commerce",
-    "mcp"
-  ],
+  "keywords": ["payment", "link", "stripe", "agentic-commerce", "mcp"],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/cursor-link/.cursor-plugin/plugin.json
+++ b/plugins/cursor-link/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "link",
   "displayName": "Link",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Complete purchases with one-time-use payment credentials from a Link wallet, using spend requests the user has approved.",
   "author": {
     "name": "Stripe"
@@ -10,7 +10,13 @@
   "repository": "https://github.com/stripe/link-cli",
   "license": "MIT",
   "logo": "./assets/link.svg",
-  "keywords": ["payment", "link", "stripe", "agentic-commerce", "mcp"],
+  "keywords": [
+    "payment",
+    "link",
+    "stripe",
+    "agentic-commerce",
+    "mcp"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/link/.claude-plugin/plugin.json
+++ b/plugins/link/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "link",
-  "version": "0.11.0",
+  "version": "0.15.0",
   "description": "Authenticate with Link, create spend requests, and retrieve one-time-use card or shared payment token credentials for user-approved purchases.",
   "author": {
     "name": "Stripe"

--- a/plugins/link/.codex-plugin/plugin.json
+++ b/plugins/link/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "link",
-  "version": "0.11.0",
+  "version": "0.15.0",
   "description": "Secure, one-time-use payment credentials from Link",
   "author": {
     "name": "Stripe",

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: 0.11.0
+version: 0.15.0
 name: create-payment-credential
 description: |
   Gets secure, one-time-use payment credentials (cards, tokens) from a Link wallet so agents can complete purchases on behalf of users. Use when the user says "get me a card", "buy something", "pay for X", "make a purchase", "I need to pay", "complete checkout", or asks to transact on any merchant site. Use when the user asks to connect or log in to or sign up for their Link account.

--- a/skills/financial-insights/SKILL.md
+++ b/skills/financial-insights/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: 0.11.0
+version: 0.15.0
 name: financial-insights
 description: |
   Reads a user's Link financial data — transactions, balances, and wallet sources — so agents can answer questions about spending and available source capabilities. Use when the user says "check my balance", "how much did I spend", "show my transactions", "what accounts are connected", "summarize my spending", "recent purchases", or asks about their financial activity, account balances, or linked sources.


### PR DESCRIPTION
**Before:** Fails due to schema parsing error
<img width="1054" height="173" alt="Screenshot 2026-08-28 at 3 43 56 PM" src="https://github.com/user-attachments/assets/b1bc3bf4-647a-483e-831e-280d535395b1" />


**After:** Successfully returns and renders shipping addresses
<img width="657" height="68" alt="Screenshot 2026-08-28 at 3 43 43 PM" src="https://github.com/user-attachments/assets/34c69142-e94d-4f96-9146-fd1584328cb8" />
