### PR TITLE
feat: Use pm.name from API in rendering payment methods list as PM label

### DIFF
--- a/packages/cli/src/commands/payment-methods/list.tsx
+++ b/packages/cli/src/commands/payment-methods/list.tsx
@@ -49,7 +49,7 @@ export const PaymentMethodsList: React.FC<PaymentMethodsListProps> = ({
       <Text bold>Payment Methods</Text>
       <Box flexDirection="column" marginTop={1}>
         {methods.map((pm) => {
-          const label =
+          const label = pm.name ??
             pm.card_details?.brand ??
             pm.bank_account_details?.bank_name ??
             'Bank account';

--- a/packages/cli/src/commands/payment-methods/list.tsx
+++ b/packages/cli/src/commands/payment-methods/list.tsx
@@ -49,7 +49,8 @@ export const PaymentMethodsList: React.FC<PaymentMethodsListProps> = ({
       <Text bold>Payment Methods</Text>
       <Box flexDirection="column" marginTop={1}>
         {methods.map((pm) => {
-          const label = pm.name ??
+          const label =
+            pm.name ??
             pm.card_details?.brand ??
             pm.bank_account_details?.bank_name ??
             'Bank account';

--- a/packages/sdk/src/resources/__tests__/payment-methods.test.ts
+++ b/packages/sdk/src/resources/__tests__/payment-methods.test.ts
@@ -38,6 +38,8 @@ describe('PaymentMethodsResource', () => {
             exp_month: 12,
             exp_year: 2028,
           },
+          name: 'Visa Credit',
+          nickname: 'Home Credit',
         },
       ],
     });
@@ -60,6 +62,8 @@ describe('PaymentMethodsResource', () => {
           exp_month: 12,
           exp_year: 2028,
         },
+        name: 'Visa Credit',
+        nickname: 'Home Credit',
       },
     ]);
   });
@@ -107,7 +111,7 @@ describe('PaymentMethodsResource', () => {
       logger: { debug },
     });
     mockFetchResponse(200, {
-      payment_details: [{ id: 'pm_secret', type: 'card', is_default: true }],
+      payment_details: [{ id: 'pm_secret', type: 'card', is_default: true, name: 'Visa Credit', nickname: 'Home Credit' }],
     });
 
     await repo.list();
@@ -119,7 +123,7 @@ describe('PaymentMethodsResource', () => {
 
   it('rejects malformed successful responses', async () => {
     mockFetchResponse(200, {
-      payment_details: [{ id: 123, type: 'card', is_default: true }],
+      payment_details: [{ id: 123, type: 'card', is_default: true, name: 'Visa Credit', nickname: 'Home Credit' }],
     });
 
     const error = await repo.list().catch((cause) => cause);

--- a/packages/sdk/src/resources/__tests__/payment-methods.test.ts
+++ b/packages/sdk/src/resources/__tests__/payment-methods.test.ts
@@ -111,7 +111,15 @@ describe('PaymentMethodsResource', () => {
       logger: { debug },
     });
     mockFetchResponse(200, {
-      payment_details: [{ id: 'pm_secret', type: 'card', is_default: true, name: 'Visa Credit', nickname: 'Home Credit' }],
+      payment_details: [
+        {
+          id: 'pm_secret',
+          type: 'card',
+          is_default: true,
+          name: 'Visa Credit',
+          nickname: 'Home Credit',
+        },
+      ],
     });
 
     await repo.list();
@@ -123,7 +131,15 @@ describe('PaymentMethodsResource', () => {
 
   it('rejects malformed successful responses', async () => {
     mockFetchResponse(200, {
-      payment_details: [{ id: 123, type: 'card', is_default: true, name: 'Visa Credit', nickname: 'Home Credit' }],
+      payment_details: [
+        {
+          id: 123,
+          type: 'card',
+          is_default: true,
+          name: 'Visa Credit',
+          nickname: 'Home Credit',
+        },
+      ],
     });
 
     const error = await repo.list().catch((cause) => cause);

--- a/packages/sdk/src/resources/payment-methods.ts
+++ b/packages/sdk/src/resources/payment-methods.ts
@@ -8,6 +8,8 @@ const paymentMethodSchema = z.looseObject({
   id: z.string(),
   type: z.string(),
   is_default: z.boolean(),
+  name: z.string(),
+  nickname: z.optional(z.string().nullable()),
 });
 const paymentMethodsResponseSchema = z.looseObject({
   payment_details: z.array(paymentMethodSchema),

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -193,6 +193,7 @@ export interface PaymentMethod {
   id: string;
   type: string;
   is_default: boolean;
+  name: string;
   nickname?: string;
   card_details?: CardDetails;
   bank_account_details?: BankAccountDetails;

--- a/plugins/cursor-link/.cursor-plugin/plugin.json
+++ b/plugins/cursor-link/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "link",
   "displayName": "Link",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Complete purchases with one-time-use payment credentials from a Link wallet, using spend requests the user has approved.",
   "author": {
     "name": "Stripe"
@@ -10,7 +10,13 @@
   "repository": "https://github.com/stripe/link-cli",
   "license": "MIT",
   "logo": "./assets/link.svg",
-  "keywords": ["payment", "link", "stripe", "agentic-commerce", "mcp"],
+  "keywords": [
+    "payment",
+    "link",
+    "stripe",
+    "agentic-commerce",
+    "mcp"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/cursor-link/.cursor-plugin/plugin.json
+++ b/plugins/cursor-link/.cursor-plugin/plugin.json
@@ -10,13 +10,7 @@
   "repository": "https://github.com/stripe/link-cli",
   "license": "MIT",
   "logo": "./assets/link.svg",
-  "keywords": [
-    "payment",
-    "link",
-    "stripe",
-    "agentic-commerce",
-    "mcp"
-  ],
+  "keywords": ["payment", "link", "stripe", "agentic-commerce", "mcp"],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json"
 }

--- a/plugins/link/.claude-plugin/plugin.json
+++ b/plugins/link/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "link",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Authenticate with Link, create spend requests, and retrieve one-time-use card or shared payment token credentials for user-approved purchases.",
   "author": {
     "name": "Stripe"

--- a/plugins/link/.codex-plugin/plugin.json
+++ b/plugins/link/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "link",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Secure, one-time-use payment credentials from Link",
   "author": {
     "name": "Stripe",

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: 0.15.0
+version: 0.15.1
 name: create-payment-credential
 description: |
   Gets secure, one-time-use payment credentials (cards, tokens) from a Link wallet so agents can complete purchases on behalf of users. Use when the user says "get me a card", "buy something", "pay for X", "make a purchase", "I need to pay", "complete checkout", or asks to transact on any merchant site. Use when the user asks to connect or log in to or sign up for their Link account.

--- a/skills/financial-insights/SKILL.md
+++ b/skills/financial-insights/SKILL.md
@@ -1,5 +1,5 @@
 ---
-version: 0.15.0
+version: 0.15.1
 name: financial-insights
 description: |
   Reads a user's Link financial data — transactions, balances, and wallet sources — so agents can answer questions about spending and available source capabilities. Use when the user says "check my balance", "how much did I spend", "show my transactions", "what accounts are connected", "summarize my spending", "recent purchases", or asks about their financial activity, account balances, or linked sources.


### PR DESCRIPTION
Aligns how we render payment methods on other link surfaces (e.g app.link.com) with what we render in the CLI output. This will help users and agents choose the correct payment method for the correct flow.