### PR TITLE
Do not render approval qr code for delegated spend requests

### DIFF
--- a/.changeset/soft-otters-cheer.md
+++ b/.changeset/soft-otters-cheer.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": patch
+---
+
+Fix `spend-request create --approve` showing the approval-waiting screen and QR code even though the request is already approved.

--- a/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
+++ b/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
@@ -330,6 +330,67 @@ describe('spend-request', () => {
     });
   });
 
+  describe('approve', () => {
+    it('CreateSpendRequest skips the approval-waiting/QR view when the request is already approved', async () => {
+      const request = makeSpendRequest({ status: 'approved' });
+      const repo = makeMockRepo(request);
+
+      const { lastFrame } = render(
+        <CreateSpendRequest
+          repository={repo}
+          params={{
+            payment_details: 'pm_1',
+            amount: 1000,
+            currency: 'usd',
+            merchant_name: 'Acme',
+            merchant_url: 'https://example.com',
+            context: 'x'.repeat(100),
+          }}
+          requestApproval
+          approve
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Spend request created');
+        expect(frame).not.toContain('Approve at:');
+        expect(frame).not.toContain('Get the Link app');
+      });
+    });
+
+    it('CreateSpendRequest still shows the approval-waiting/QR view when requestApproval is set and the request is not yet approved', async () => {
+      const created = makeSpendRequest({
+        status: 'created',
+        approval_url: 'https://app.link.com/approve/sr_test',
+      });
+      const repo = makeMockRepo(created);
+
+      const { lastFrame } = render(
+        <CreateSpendRequest
+          repository={repo}
+          params={{
+            payment_details: 'pm_1',
+            amount: 1000,
+            currency: 'usd',
+            merchant_name: 'Acme',
+            merchant_url: 'https://example.com',
+            context: 'x'.repeat(100),
+          }}
+          requestApproval
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Approve at:');
+        expect(frame).toContain('Get the Link app');
+      });
+    });
+  });
+
   describe('requires_action', () => {
     it('CreateSpendRequest shows next_action details for a non-auto_resume type', async () => {
       const request = makeSpendRequest({

--- a/packages/cli/src/commands/spend-request/create.tsx
+++ b/packages/cli/src/commands/spend-request/create.tsx
@@ -26,6 +26,7 @@ interface CreateSpendRequestProps {
   repository: ISpendRequestResource;
   params: CreateSpendRequestParams;
   requestApproval?: boolean;
+  approve?: boolean;
   outputFile?: string;
   force?: boolean;
   onComplete: (result: SpendRequest | null) => void;
@@ -35,6 +36,7 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
   repository,
   params,
   requestApproval = false,
+  approve = false,
   outputFile,
   force,
   onComplete,
@@ -210,7 +212,7 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
             result.status_details?.requires_action?.next_action ?? null,
           );
           setStatus('requires_action');
-        } else if (requestApproval) {
+        } else if (requestApproval && result.status !== 'approved') {
           setStatus('waiting');
         } else {
           setStatus('success');
@@ -518,7 +520,7 @@ export const CreateSpendRequest: React.FC<CreateSpendRequestProps> = ({
             )}
           </Box>
         )}
-        <AppDownloadQrCodes />
+        {!approve && <AppDownloadQrCodes />}
       </Box>
     );
   }

--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -284,6 +284,7 @@ export function createSpendRequestCli(
             repository={repository}
             params={createParams}
             requestApproval={requestApproval}
+            approve={opts.approve ? true : undefined}
             outputFile={outputFile}
             force={forceOverwrite}
             onComplete={(result) => {


### PR DESCRIPTION
Updated to not show approval qr code for delegated spend requests