### PR TITLE
Document email-prefilled Link URLs

### DIFF
--- a/.changeset/bright-emails-smile.md
+++ b/.changeset/bright-emails-smile.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": patch
+---
+
+Tell agents to prefill known email addresses in Link OAuth and spend-request step-up URLs.

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -104,6 +104,10 @@ Replace `<your-agent-name>` with the name of your agent or application (for exam
 
 The response includes a `_next` command — run it to poll until authenticated. If your environment cannot relay the verification code while a separate polling command blocks I/O, use inline polling instead: `auth login --client-name "<name>" --interval 5 --timeout 300`. This yields the code immediately then polls in the same command.
 
+If the user's email is already known, save them time by adding it as the
+URL-encoded `fromEmail` query parameter to any `app.link.com` verification or
+action URL; preserve existing query parameters.
+
 DO NOT PROCEED until the user is authenticated with Link.
 
 Always check the current authentication status before starting a new login flow — the user might already be logged in.

--- a/skills/link-cli/SKILL.md
+++ b/skills/link-cli/SKILL.md
@@ -100,6 +100,10 @@ Authorization is a multi-step flow:
 2. Run the returned `_next.command` immediately to poll for approval; do not wait for another user reply before polling.
 3. Continue only when the result reports successful authentication and the required grants.
 
+If the user's email is already known, save them time by adding it as the
+URL-encoded `fromEmail` query parameter to any `app.link.com` verification or
+action URL; preserve existing query parameters.
+
 The response includes a `_next` command — run it to poll until authenticated. If your environment cannot relay the verification code while a separate polling command blocks I/O, use inline polling instead by adding `--interval 5 --timeout 300` to the initial `auth login` or `auth upgrade` command. This yields the code immediately then polls in the same command.
 
 DO NOT PROCEED until the user is authenticated with Link.


### PR DESCRIPTION
- Tell agents to append a URL-encoded fromEmail value to Link OAuth URLs when the user's email is already known.
- Apply the same time-saving guidance to spend-request step-up action URLs.
