### PR TITLE
feat: Add `--attempt-trace` to `link-cli report`

### DIFF
--- a/.changeset/lucky-guides-follow.md
+++ b/.changeset/lucky-guides-follow.md
@@ -1,0 +1,6 @@
+---
+"@stripe/link-cli": minor
+"@stripe/link-sdk": minor
+---
+
+Add `--attempt-trace` to `link-cli report` (and `attempt_trace` to the SDK's `CreateReportParams`): a step-by-step account of the path the agent took on a domain, written so another agent could follow it. Sent for successes and failures alike — the dead ends on a failed attempt are the useful part. The API truncates past 8000 characters rather than rejecting, so the flag carries no client-side length limit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Commands in `packages/cli/src/cli.tsx` (incur framework). Each has two output mo
 - **Interactive** (default): Ink/React components from `packages/cli/src/commands/`
 - **JSON** (`--format json`): JSON to stdout, errors as JSON with `code` and `message` fields with exit code 1
 
-Commands: `auth login|logout|status`, `user-info retrieve`, `spend-request create|update|retrieve|request-approval|cancel`, `payment-methods list`, `shipping-address list`, `mpp pay|decode`, `serve`.
+Commands: `auth login|logout|status`, `user-info retrieve`, `spend-request create|update|retrieve|request-approval|cancel`, `payment-methods list`, `shipping-address list`, `mpp pay|decode`, `report`, `serve`.
 
 The CLI also runs as an MCP server (`--mcp`) and serves skill files via `skills` subcommand, both provided by incur.
 
@@ -115,6 +115,12 @@ Key input field notes:
 ### onboard command
 
 - `onboard` — Guided setup: authenticates (skips if already logged in), checks payment methods (prompts to add one if missing, shows picker if multiple), shows app download QR code, then runs the full demo. Requires a TTY.
+
+### report command
+
+- `report --domain <d> --outcome <success|blocked|abandoned> --spend-request-id <lsrq_...> [--tag <t>]... [--step <s>] [--freeform-context <s>] [--attempt-trace <s>]` — records the outcome of a purchase attempt. Options in `packages/cli/src/commands/report/schema.ts`, SDK params in `CreateReportParams`. API endpoint: `/agent_observations`. Output policy is `agent-only`.
+- `--step` is where the agent was when the outcome occurred (max 500). `--attempt-trace` is the whole path it took, one numbered line per step, intended to be replayable by another agent. Both are optional and independent.
+- `--attempt-trace` intentionally carries **no** zod `.max()`. The API truncates at `REPORT_ATTEMPT_TRACE_MAX_LENGTH` (8000, exported from the SDK) and still records the report, so client-side rejection would trade a long narrative for a lost outcome. `--step` and `--freeform-context` keep their `.max(500)` because the API rejects those outright.
 
 ### serve command
 

--- a/README.md
+++ b/README.md
@@ -370,9 +370,17 @@ link-cli report --domain shop.example.com --outcome blocked --spend-request-id l
 # Abandoned due to timeout
 link-cli report --domain shop.example.com --outcome abandoned --spend-request-id lsrq_abc123 \
   --tag timeout
+
+# With a step-by-step account of the path taken
+link-cli report --domain shop.example.com --outcome success --spend-request-id lsrq_abc123 \
+  --attempt-trace '1. / — clicked "Shop" → category grid
+2. /checkout — email required before shipping unlocks; entered [email]
+3. /checkout — clicked "Pay now" → order confirmed'
 ```
 
 Outcomes: `success`, `blocked`, `abandoned`. Tags: `stripe_checkout`, `captcha`, `anti_bot_script`, `cdn_block`, `waf_block`, `dns_block`, `rate_limited`, `login_required`, `3ds_challenge`, `page_inaccessible`, `timeout`, `site_error`, `payment_declined`, `other`.
+
+`--step` records where the agent was when the outcome occurred. `--attempt-trace` is the whole path: one numbered line per step, each giving the URL path, the label acted on, the action, and the observed result, so another agent can follow it. Send it on failures too — the dead ends are the useful part. Omit the buyer's personal data and write `[email]`, `[address]` in its place. Over 8000 characters is truncated by the server rather than rejected, so send the full narrative instead of skipping the report.
 
 
 

--- a/packages/cli/src/commands/report/index.tsx
+++ b/packages/cli/src/commands/report/index.tsx
@@ -24,6 +24,7 @@ export function createReportCli(
         tags: c.options.tag,
         step: c.options.step,
         freeform_context: c.options.freeformContext,
+        attempt_trace: c.options.attemptTrace,
       });
       return result;
     },

--- a/packages/cli/src/commands/report/schema.ts
+++ b/packages/cli/src/commands/report/schema.ts
@@ -1,4 +1,8 @@
-import { REPORT_OUTCOMES, REPORT_TAGS } from '@stripe/link-sdk';
+import {
+  REPORT_ATTEMPT_TRACE_MAX_LENGTH,
+  REPORT_OUTCOMES,
+  REPORT_TAGS,
+} from '@stripe/link-sdk';
 import { z } from 'incur';
 
 export const reportOptions = z.object({
@@ -21,4 +25,13 @@ export const reportOptions = z.object({
     .max(500)
     .optional()
     .describe('Additional context (max 500 chars)'),
+  // Deliberately not `.max(REPORT_ATTEMPT_TRACE_MAX_LENGTH)`: the API truncates
+  // an over-long attempt_trace and still records the report, so rejecting it here
+  // would turn a long narrative into a lost outcome.
+  attemptTrace: z
+    .string()
+    .optional()
+    .describe(
+      `A detailed, replayable account of what you did on this domain, written so another agent could follow it. Use one numbered line per step. For each step include: the URL path, the visible label or selector you acted on, the action you took, and what you observed as a result. Quote error messages and challenge text verbatim. If you failed, include the steps you tried and the specific reason each one failed, including dead ends — those are as valuable as the path that worked. Do not include the buyer's personal data: no email, name, address, phone, card number, or order number. Refer to them as [email], [address], etc. Anything past ${REPORT_ATTEMPT_TRACE_MAX_LENGTH} chars is truncated by the server, not rejected — send it anyway rather than skipping the report.`,
+    ),
 });

--- a/packages/sdk/src/resources/__tests__/report.test.ts
+++ b/packages/sdk/src/resources/__tests__/report.test.ts
@@ -1,5 +1,6 @@
 import { LinkApiError, LinkTransportError } from '@/errors';
 import type { CreateReportParams, ReportRecord } from '@/resources/interfaces';
+import { REPORT_ATTEMPT_TRACE_MAX_LENGTH } from '@/resources/interfaces';
 import { ReportResource } from '@/resources/report';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -85,6 +86,37 @@ describe('ReportResource', () => {
       expect(body.tags).toBeUndefined();
       expect(body.step).toBeUndefined();
       expect(body.freeform_context).toBeUndefined();
+      expect(body.attempt_trace).toBeUndefined();
+    });
+
+    it('sends attempt_trace in the body when provided', async () => {
+      mockFetchResponse(201, successResponse);
+
+      const attemptTrace = [
+        '1. / — clicked "Shop" → category grid',
+        '2. /checkout — email required before shipping unlocks; entered [email]',
+        '3. /checkout — clicked "Pay now" → order confirmed',
+      ].join('\n');
+
+      await resource.create({ ...validParams, attempt_trace: attemptTrace });
+
+      const [, opts] = mockFetch.mock.calls[0]!;
+      expect(JSON.parse(opts.body).attempt_trace).toBe(attemptTrace);
+    });
+
+    it('sends an attempt_trace over the cap unchanged and lets the API truncate', async () => {
+      mockFetchResponse(201, successResponse);
+
+      const oversized = 'x'.repeat(REPORT_ATTEMPT_TRACE_MAX_LENGTH + 500);
+
+      const result = await resource.create({
+        ...validParams,
+        attempt_trace: oversized,
+      });
+
+      const [, opts] = mockFetch.mock.calls[0]!;
+      expect(JSON.parse(opts.body).attempt_trace).toBe(oversized);
+      expect(result).toEqual(successResponse);
     });
 
     it('retries with refreshed token on 401', async () => {

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -138,6 +138,12 @@ export const REPORT_TAGS = [
 ] as const;
 export type ReportTag = (typeof REPORT_TAGS)[number];
 
+/**
+ * Server-side cap on `attempt_trace`. Longer values are truncated by the API
+ * rather than rejected, so callers do not need to pre-trim.
+ */
+export const REPORT_ATTEMPT_TRACE_MAX_LENGTH = 8000;
+
 export interface CreateReportParams {
   domain: string;
   outcome: ReportOutcome;
@@ -145,6 +151,7 @@ export interface CreateReportParams {
   tags?: ReportTag[];
   step?: string;
   freeform_context?: string;
+  attempt_trace?: string;
 }
 
 export interface ReportRecord {

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -368,7 +368,8 @@ link-cli report \
   --spend-request-id <lsrq_...> \
   [--tag <tag>] \
   [--step <step>] \
-  [--freeform-context "<details>"]
+  [--freeform-context "<details>"] \
+  [--attempt-trace "<step-by-step account>"]
 ```
 
 ### When to report
@@ -398,6 +399,35 @@ Add one or more `--tag` flags to classify what happened. Prefer the most specifi
 | `payment_declined` | Payment was declined by processor |
 | `other` | Other (describe in freeform-context) |
 
+### Attempt trace
+
+`--attempt-trace` is a step-by-step account of the path you took on this domain, written so another agent could follow it. `--step` records where you were when the outcome occurred; the trace is the whole path.
+
+Send it for every outcome, not just `success`. The dead ends on a failed attempt are what keep the next agent from spending tokens on them.
+
+Write one numbered line per step. On each line give the URL path, the visible label or selector you acted on, the action, and what you observed. Quote error messages and challenge text verbatim. When you fail, say what you tried and the specific reason each attempt failed.
+
+Do not put the buyer's personal data in it — no email, name, address, phone, card number, or order number. Write `[email]`, `[address]`, and so on instead.
+
+```
+1. / — clicked "Shop" in top nav → category grid
+2. /collections/mice — clicked product tile "Magic Mouse" → PDP
+3. /products/magic-mouse — clicked "Add to cart" → cart drawer opened
+4. /checkout — email field required before shipping; entered [email]
+5. /checkout — "Continue to shipping" disabled until ZIP entered; entered [address]
+6. /checkout — payment step rendered in a cross-origin iframe titled
+   "Secure payment"; Payment Element detected, used Link credential
+7. /checkout — clicked "Pay now" → hCaptcha challenge appeared, text:
+   "Verify you are human". Retried once, challenge did not reappear.
+8. /checkout/thank_you — order confirmed
+OUTCOME: success. Notes: email must be entered before the shipping form
+unlocks — entering shipping first silently clears it.
+```
+
+That last line is the kind of detail worth carrying: no tag or enum captures it.
+
+A trace longer than 8000 characters is truncated by the server, not rejected, and the report is still recorded. Send the full narrative rather than trimming it or skipping the report.
+
 ### Examples
 
 ```bash
@@ -409,6 +439,17 @@ link-cli report --domain shop.example.com --outcome blocked --spend-request-id l
 
 # Abandoned due to site error
 link-cli report --domain shop.example.com --outcome abandoned --spend-request-id lsrq_abc123 --tag site_error --freeform-context "500 error on payment submission"
+
+# Success, with the path recorded for the next agent
+link-cli report --domain shop.example.com --outcome success --spend-request-id lsrq_abc123 \
+  --attempt-trace "$(cat <<'EOF'
+1. / — clicked "Shop" in top nav → category grid
+2. /products/magic-mouse — clicked "Add to cart" → cart drawer opened
+3. /checkout — email required before shipping unlocks; entered [email]
+4. /checkout — clicked "Pay now" → order confirmed
+OUTCOME: success.
+EOF
+)"
 ```
 
 Report output is agent-only (not shown to the user). Reporting is encouraged but not required, including when the purchase failed.


### PR DESCRIPTION
A step-by-step account of the path the agent took on a domain to attempt a payment. Sent for every outcome, not just `success`. 

Deliberately no zod `.max()`. The API truncates past `REPORT_ATTEMPT_TRACE_MAX_LENGTH` (8000) and still records the report, so rejecting client-side would trade a long narrative for a lost outcome. 

Both the description and the docs tell agents to keep the buyer's personal data out of it and write `[email]`/`[address]` instead.

Requires the server-side `attempt_trace` field on `POST /agent_observations`, which ships separately and is not deployed yet. 

Test plan
- `pnpm run test` — 310 tests pass, including new SDK coverage for sending `attempt_trace` in the body, omitting it, and passing an over-cap value through unchanged for the server to truncate.
- `pnpm run typecheck` and `pnpm biome check .` clean.
- `node packages/cli/dist/cli.js report --schema` shows `attemptTrace` with no `maxLength`, while `step`/`freeformContext` keep theirs.

[ Will manually test once the API updates ship ]