### PR TITLE
feat: Handle post-approval amount updates in CLI

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -912,6 +912,31 @@ describe('production mode', () => {
       expect(sentBody.merchant_url).toBe('https://updated.com');
     });
 
+    it('uses the delegated update endpoint when --approve is set', async () => {
+      setNextResponse(200, {
+        ...BASE_REQUEST,
+        amount: 6000,
+        approval_url: 'https://app.link.com/approve/lsrq_prod_001',
+      });
+
+      const result = await runProdCli(
+        'spend-request',
+        'update',
+        'lsrq_prod_001',
+        '--amount',
+        '6000',
+        '--approve',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest.method).toBe('POST');
+      expect(lastRequest.url).toBe(
+        '/spend_requests/lsrq_prod_001/update_delegated',
+      );
+      expect(JSON.parse(lastRequest.body)).toEqual({ amount: 6000 });
+    });
+
     it('surfaces API errors for update', async () => {
       setNextResponse(409, {
         error: { message: 'Cannot update request in pending_approval status' },

--- a/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
+++ b/packages/cli/src/commands/spend-request/__tests__/spend-request.test.tsx
@@ -73,6 +73,119 @@ function makeSequentialMockRepo(
 }
 
 describe('spend-request', () => {
+  describe('UpdateSpendRequest', () => {
+    it('shows the approval URL while polling a delegated amount update', async () => {
+      const request = makeSpendRequest({
+        amount: 1000,
+        approval_url: 'https://app.link.com/approve/sr_test',
+      });
+      const repo = sanitizeResource({
+        update: vi.fn(async () => request),
+        retrieve: vi.fn(() => new Promise<SpendRequest | null>(() => {})),
+      } as unknown as ISpendRequestResource);
+      const onComplete = vi.fn();
+
+      const { lastFrame } = render(
+        <UpdateSpendRequest
+          repository={repo}
+          id="sr_test"
+          params={{ amount: 2000 }}
+          onComplete={onComplete}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Approve at:');
+        expect(frame).toContain('https://app.link.com/approve/sr_test');
+        expect(frame).toContain('Waiting for approval');
+        expect(frame).not.toContain('Spend request updated');
+        expect(onComplete).not.toHaveBeenCalled();
+      });
+    });
+
+    it('shows the applied amount after the update is approved', async () => {
+      const pending = makeSpendRequest({
+        amount: 1000,
+        approval_url: 'https://app.link.com/approve/sr_test',
+      });
+      const approved = makeSpendRequest({
+        amount: 2000,
+        approval_url: 'https://app.link.com/approve/sr_test',
+      });
+      const repo = sanitizeResource({
+        update: vi.fn(async () => pending),
+        retrieve: vi.fn(async () => approved),
+      } as unknown as ISpendRequestResource);
+
+      const { lastFrame } = render(
+        <UpdateSpendRequest
+          repository={repo}
+          id="sr_test"
+          params={{ amount: 2000 }}
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Spend request updated');
+        expect(frame).toMatch(/Amount:\s+2000/);
+      });
+    });
+
+    it('shows a denied result when the approval URL disappears', async () => {
+      const pending = makeSpendRequest({
+        amount: 1000,
+        approval_url: 'https://app.link.com/approve/sr_test',
+      });
+      const denied = makeSpendRequest({
+        amount: 1000,
+        approval_url: undefined,
+      });
+      const repo = sanitizeResource({
+        update: vi.fn(async () => pending),
+        retrieve: vi.fn(async () => denied),
+      } as unknown as ISpendRequestResource);
+
+      const { lastFrame } = render(
+        <UpdateSpendRequest
+          repository={repo}
+          id="sr_test"
+          params={{ amount: 2000 }}
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Spend request update denied');
+        expect(frame).toMatch(/Amount:\s+1000/);
+      });
+    });
+
+    it('renders a zero amount from the updated response', async () => {
+      const request = makeSpendRequest({ amount: 0, approval_url: undefined });
+      const repo = makeMockRepo(request);
+
+      const { lastFrame } = render(
+        <UpdateSpendRequest
+          repository={repo}
+          id="sr_test"
+          params={{ amount: 0 }}
+          onComplete={() => {}}
+        />,
+      );
+
+      await vi.waitFor(() => {
+        const frame = lastFrame();
+        expect(frame).toContain('Spend request updated');
+        expect(frame).toMatch(/Amount:\s+0/);
+        expect(frame).not.toContain('Amount: N/A');
+      });
+    });
+  });
+
   describe('verification_url', () => {
     it('CreateSpendRequest surfaces verification_url on additional_verification_required error', async () => {
       const error = new LinkApiError(

--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -402,6 +402,9 @@ export function createSpendRequestCli(
         params.totals = opts.total.map((item: unknown) =>
           typeof item === 'string' ? parseTotalFlag(item) : item,
         );
+      if (opts.approve !== undefined) {
+        params.approve = opts.approve;
+      }
 
       if (!c.agent && !c.formatExplicit) {
         let capturedResult: SpendRequest | null = null;

--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -166,4 +166,8 @@ export const updateOptions = z.object({
     .describe(
       'Total (repeatable, key:value format). Keys: type (required; one of: subtotal, tax, total, items_base_amount, items_discount, discount, fulfillment, shipping, fee, gift_wrap, tip, store_credit), display_text (required), amount (required). Example: "type:total,display_text:Total,amount:5000"',
     ),
+  approve: z
+    .boolean()
+    .default(false)
+    .describe('Use the delegated approval flow for this update'),
 });

--- a/packages/cli/src/commands/spend-request/update.tsx
+++ b/packages/cli/src/commands/spend-request/update.tsx
@@ -3,11 +3,17 @@ import type {
   SpendRequest,
   UpdateSpendRequestParams,
 } from '@stripe/link-sdk';
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import Spinner from 'ink-spinner';
 import type React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useAsyncAction } from '../../hooks/use-async-action';
+import { openUrl } from '../../utils/open-url';
+import {
+  type SpendRequestUpdatePollResult,
+  pollUntilSpendRequestUpdate,
+} from '../../utils/poll-until-spend-request-update';
+import { ApprovalWaitingView } from './approval-waiting-view';
 
 interface UpdateSpendRequestProps {
   repository: ISpendRequestResource;
@@ -16,19 +22,65 @@ interface UpdateSpendRequestProps {
   onComplete: (result: SpendRequest | null) => void;
 }
 
+type UpdateResult =
+  | SpendRequestUpdatePollResult
+  | {
+      request: SpendRequest;
+      outcome: 'updated';
+    };
+
 export const UpdateSpendRequest: React.FC<UpdateSpendRequestProps> = ({
   repository,
   id,
   params,
   onComplete,
 }) => {
-  const action = useCallback(
-    () => repository.update(id, params),
-    [repository, id, params],
+  const [pendingApproval, setPendingApproval] = useState<SpendRequest | null>(
+    null,
   );
-  const { status, data: request, error } = useAsyncAction(action, onComplete);
+
+  const action = useCallback(async (): Promise<UpdateResult> => {
+    const request = await repository.update(id, params);
+    if (
+      params.amount !== undefined &&
+      request.status === 'approved' &&
+      request.approval_url
+    ) {
+      setPendingApproval(request);
+      return pollUntilSpendRequestUpdate(repository, id, params.amount);
+    }
+    return { request, outcome: 'updated' };
+  }, [repository, id, params]);
+
+  const handleComplete = useCallback(
+    (result: UpdateResult | null) => onComplete(result?.request ?? null),
+    [onComplete],
+  );
+  const {
+    status,
+    data: result,
+    error,
+  } = useAsyncAction(action, handleComplete);
+  const request = result?.request ?? pendingApproval;
+
+  useInput(
+    (_input, key) => {
+      if (key.return && pendingApproval?.approval_url) {
+        openUrl(pendingApproval.approval_url);
+      }
+    },
+    { isActive: status === 'loading' && pendingApproval !== null },
+  );
 
   if (status === 'loading') {
+    if (pendingApproval?.approval_url) {
+      return (
+        <ApprovalWaitingView
+          status="polling"
+          approvalUrl={pendingApproval.approval_url}
+        />
+      );
+    }
     return (
       <Box>
         <Text color="cyan">
@@ -47,6 +99,22 @@ export const UpdateSpendRequest: React.FC<UpdateSpendRequestProps> = ({
     );
   }
 
+  if (result?.outcome === 'denied') {
+    return (
+      <Box flexDirection="column">
+        <Text color="yellow">✗ Spend request update denied</Text>
+        <Box flexDirection="column" marginTop={1} paddingX={2}>
+          <Text>
+            ID: <Text bold>{request?.id}</Text>
+          </Text>
+          <Text>
+            Amount: <Text bold>{request?.amount ?? 'N/A'}</Text>
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
   return (
     <Box flexDirection="column">
       <Text color="green">✓ Spend request updated</Text>
@@ -60,10 +128,7 @@ export const UpdateSpendRequest: React.FC<UpdateSpendRequestProps> = ({
         <Text>
           Amount:{' '}
           <Text bold>
-            {(() => {
-              const t = request?.totals?.find((t) => t.type === 'total');
-              return t ? String(t.amount) : 'N/A';
-            })()}
+            {request?.amount !== undefined ? String(request.amount) : 'N/A'}
           </Text>
         </Text>
         <Text>

--- a/packages/cli/src/utils/__tests__/poll-until-spend-request-update.test.ts
+++ b/packages/cli/src/utils/__tests__/poll-until-spend-request-update.test.ts
@@ -1,0 +1,55 @@
+import type { ISpendRequestResource, SpendRequest } from '@stripe/link-sdk';
+import { describe, expect, it, vi } from 'vitest';
+import { pollUntilSpendRequestUpdate } from '../poll-until-spend-request-update';
+
+function makeRequest(overrides: Partial<SpendRequest>): SpendRequest {
+  return {
+    id: 'sr_1',
+    status: 'approved',
+    amount: 1000,
+    approval_url: 'https://app.link.com/approve/sr_1',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('pollUntilSpendRequestUpdate', () => {
+  it('keeps polling until the pending amount is applied', async () => {
+    const retrieve = vi
+      .fn()
+      .mockResolvedValueOnce(makeRequest({ amount: 1000 }))
+      .mockResolvedValueOnce(makeRequest({ amount: 2000 }));
+    const repository = { retrieve } as unknown as ISpendRequestResource;
+
+    const result = await pollUntilSpendRequestUpdate(repository, 'sr_1', 2000, {
+      pollIntervalMs: 1,
+    });
+
+    expect(result.outcome).toBe('approved');
+    expect(result.request.amount).toBe(2000);
+    expect(retrieve).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops as denied when the approval URL disappears', async () => {
+    const request = makeRequest({ approval_url: undefined });
+    const repository = {
+      retrieve: vi.fn(async () => request),
+    } as unknown as ISpendRequestResource;
+
+    const result = await pollUntilSpendRequestUpdate(repository, 'sr_1', 2000);
+
+    expect(result).toEqual({ request, outcome: 'denied' });
+  });
+
+  it('treats a matching amount as approved even if the URL also disappears', async () => {
+    const request = makeRequest({ amount: 2000, approval_url: undefined });
+    const repository = {
+      retrieve: vi.fn(async () => request),
+    } as unknown as ISpendRequestResource;
+
+    const result = await pollUntilSpendRequestUpdate(repository, 'sr_1', 2000);
+
+    expect(result.outcome).toBe('approved');
+  });
+});

--- a/packages/cli/src/utils/poll-until-spend-request-update.ts
+++ b/packages/cli/src/utils/poll-until-spend-request-update.ts
@@ -1,0 +1,43 @@
+import type { ISpendRequestResource, SpendRequest } from '@stripe/link-sdk';
+
+export interface SpendRequestUpdatePollOptions {
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+}
+
+export interface SpendRequestUpdatePollResult {
+  request: SpendRequest;
+  outcome: 'approved' | 'denied';
+}
+
+export async function pollUntilSpendRequestUpdate(
+  repository: ISpendRequestResource,
+  id: string,
+  pendingAmount: number,
+  options: SpendRequestUpdatePollOptions = {},
+): Promise<SpendRequestUpdatePollResult> {
+  const pollIntervalMs = options.pollIntervalMs ?? 2000;
+  const timeoutMs = options.timeoutMs ?? 300_000;
+  const startTime = Date.now();
+
+  while (true) {
+    if (Date.now() - startTime > timeoutMs) {
+      throw new Error('Spend request update polling timed out');
+    }
+
+    const request = await repository.retrieve(id);
+    if (!request) {
+      throw new Error(`Spend request ${id} not found`);
+    }
+
+    if (request.amount === pendingAmount) {
+      return { request, outcome: 'approved' };
+    }
+
+    if (!request.approval_url) {
+      return { request, outcome: 'denied' };
+    }
+
+    await new Promise<void>((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+}

--- a/packages/sdk/src/resources/__tests__/spend-request.test.ts
+++ b/packages/sdk/src/resources/__tests__/spend-request.test.ts
@@ -270,6 +270,32 @@ describe('SpendRequestResource', () => {
       expect(opts.body).toBe(JSON.stringify({ payment_details: 'pd_new' }));
     });
 
+    it('sends delegated updates to update_delegated without the approve routing flag', async () => {
+      mockFetchResponse(200, {
+        ...spendRequestResponse,
+        amount: 6000,
+        approval_url: 'https://app.link.com/approve/si_123',
+      });
+
+      await repo.update('si_123', { amount: 6000, approve: true });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.link.com/spend_requests/si_123/update_delegated',
+        expect.objectContaining({ body: JSON.stringify({ amount: 6000 }) }),
+      );
+    });
+
+    it('uses the standard endpoint when approve is false', async () => {
+      mockFetchResponse(200, { ...spendRequestResponse, amount: 6000 });
+
+      await repo.update('si_123', { amount: 6000, approve: false });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.link.com/spend_requests/si_123',
+        expect.objectContaining({ body: JSON.stringify({ amount: 6000 }) }),
+      );
+    });
+
     it('returns updated SpendRequest on success', async () => {
       const updated = { ...spendRequestResponse, payment_details: 'pd_new' };
       mockFetchResponse(200, updated);

--- a/packages/sdk/src/resources/spend-request.ts
+++ b/packages/sdk/src/resources/spend-request.ts
@@ -50,6 +50,10 @@ type InternalCreateSpendRequestParams = CreateSpendRequestParams & {
   expires_at?: number;
 };
 
+type InternalUpdateSpendRequestParams = UpdateSpendRequestParams & {
+  approve?: boolean;
+};
+
 /** Normalizes the legacy string SPT response into the current object shape. */
 function parseSpendRequest(value: unknown): SpendRequest {
   return spendRequestSchema.parse(value) as SpendRequest;
@@ -116,13 +120,17 @@ export class SpendRequestResource
 
   async update(
     id: string,
-    params: UpdateSpendRequestParams,
+    params: InternalUpdateSpendRequestParams,
   ): Promise<SpendRequest> {
+    const { approve, ...body } = params;
+    const url = approve
+      ? `${this.endpoint}/${id}/update_delegated`
+      : `${this.endpoint}/${id}`;
     const { status, data, rawBody } = await this.apiFetch({
       method: 'POST',
-      url: `${this.endpoint}/${id}`,
+      url,
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(params),
+      body: JSON.stringify(body),
     });
 
     if (status < 200 || status >= 300) {


### PR DESCRIPTION
Update the `spend-request update` command to handle post-approval amount increase proposals. If the agent decides that it needs more funds post-approval to complete the purchase, it can propose a new amount via the `spend-request update --amount=<new_amount>` command. This would generate a new approval URL for the user to visit and approve or deny the amount increase. Approving the new proposed amount would increase the hold on the user's PM in-place rather than creating a new hold.


https://github.com/user-attachments/assets/44b2a407-851d-4ea9-be4e-21ee38d4f206


