### PR TITLE
Expand user-info to surface spend limits and step-up status

### DIFF
--- a/.changeset/curvy-wallets-report.md
+++ b/.changeset/curvy-wallets-report.md
@@ -1,0 +1,6 @@
+---
+'@stripe/link-sdk': patch
+'@stripe/link-cli': patch
+---
+
+Expose Agent Wallet spend limits and user step-up status through user-info retrieve.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Commands in `packages/cli/src/cli.tsx` (incur framework). Each has two output mo
 - **Interactive** (default): Ink/React components from `packages/cli/src/commands/`
 - **JSON** (`--format json`): JSON to stdout, errors as JSON with `code` and `message` fields with exit code 1
 
-Commands: `auth login|logout|status`, `spend-request create|update|retrieve|request-approval|cancel`, `payment-methods list`, `shipping-address list`, `mpp pay|decode`, `serve`.
+Commands: `auth login|logout|status`, `user-info retrieve`, `spend-request create|update|retrieve|request-approval|cancel`, `payment-methods list`, `shipping-address list`, `mpp pay|decode`, `serve`.
 
 The CLI also runs as an MCP server (`--mcp`) and serves skill files via `skills` subcommand, both provided by incur.
 
@@ -91,6 +91,13 @@ Key input field notes:
 - `card` credentials include `billing_address` (name, line1, line2, city, state, postal_code, country) and `valid_until` (ISO date string — when the card expires/stops working)
 - `--output-file <path>` on `retrieve` or `create` writes full card credentials to a local file (0600 permissions) and redacts card data in stdout. `--force` allows overwriting an existing file.
 - `create` also accepts an undocumented `--expires-at <unix_seconds>` to override the default 12-hour spend request expiration (3 hours to 7 days in the future). It's deliberately excluded from `--schema`/`--llms-full` output and from README/SKILL.md: it's gated to an allow-list of OAuth clients server-side, and most callers get a 400 (`"expires_at is not supported for this client"`) if they try it — don't document or suggest it to general agents.
+
+### user-info retrieve
+
+- `user-info retrieve` returns the existing identity fields and can include `agent_wallet_spend_limits` and `agent_wallet_step_up` enrichment.
+- Spend limits contain per-transaction, daily, and 30-day values. Finite values are cents because `/userinfo` does not return currency. A `null` limit or remaining amount explicitly means unlimited; `used` remains numeric.
+- Either enrichment object can be omitted independently when enrichment is disabled or unavailable. Do not interpret omission as unlimited or as a default step-up status.
+- Step-up status is one of `not_required`, `ssn_verification`, `identity_verification`, `contact_support`, or `complete`. It is informational and does not change spend-request or `requires_action` handling.
 
 ### mpp pay
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,29 @@ link-cli auth login
 
 You receive a verification URL and a short phrase. Visit the URL, log in to your Link account, and enter the phrase to approve the connection.
 
+### Retrieve user info
+
+```bash
+link-cli user-info retrieve --format json
+```
+
+In addition to identity fields, the response can include Agent Wallet spend limits and step-up status:
+
+```json
+{
+  "email": "jane@example.com",
+  "name": "Jane Doe",
+  "agent_wallet_spend_limits": {
+    "per_transaction": { "limit": 50000 },
+    "daily": { "limit": 500000, "used": 120000, "remaining": 380000 },
+    "thirty_day": { "limit": null, "used": 600000, "remaining": null }
+  },
+  "agent_wallet_step_up": { "status": "not_required" }
+}
+```
+
+Finite spend-limit values are cents because this response does not include a currency. A `null` limit or remaining amount means unlimited. Either Agent Wallet object can be absent when backend enrichment is unavailable; absence does not imply a limit or step-up status.
+
 ### List payment methods
 
 ```bash

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -2414,6 +2414,12 @@ describe('production mode', () => {
       setResponseForUrl('/userinfo', 200, {
         email: 'user@example.com',
         name: 'Test User',
+        agent_wallet_spend_limits: {
+          per_transaction: { limit: null },
+          daily: { limit: 500000, used: 120000, remaining: 380000 },
+          thirty_day: { limit: null, used: 600000, remaining: null },
+        },
+        agent_wallet_step_up: { status: 'not_required' },
       });
 
       const result = await runProdCliWithEnv(
@@ -2426,6 +2432,12 @@ describe('production mode', () => {
       expect(result.exitCode).toBe(0);
       const output = parseJson(result.stdout) as Record<string, unknown>;
       expect(output.email).toBe('user@example.com');
+      expect(output.agent_wallet_spend_limits).toEqual({
+        per_transaction: { limit: null },
+        daily: { limit: 500000, used: 120000, remaining: 380000 },
+        thirty_day: { limit: null, used: 600000, remaining: null },
+      });
+      expect(output.agent_wallet_step_up).toEqual({ status: 'not_required' });
       const userInfoRequest = requests.find((r) => r.url === '/userinfo');
       expect(userInfoRequest).toBeDefined();
       expect(userInfoRequest?.headers.authorization).toBe(

--- a/packages/cli/src/commands/user-info/index.tsx
+++ b/packages/cli/src/commands/user-info/index.tsx
@@ -16,7 +16,8 @@ export function createUserInfoCli(
   });
 
   cli.command('retrieve', {
-    description: 'Retrieve user info (email, name, phone)',
+    description:
+      'Retrieve user info, including optional Agent Wallet spend limits and step-up status',
     outputPolicy: 'agent-only' as const,
     middleware: [requireAuth(authStorage, envAccessToken)],
     async run(c) {

--- a/packages/cli/src/commands/user-info/retrieve.test.tsx
+++ b/packages/cli/src/commands/user-info/retrieve.test.tsx
@@ -1,0 +1,105 @@
+import type { IUserInfoResource, UserInfo } from '@stripe/link-sdk';
+import { render } from 'ink-testing-library';
+import { describe, expect, it, vi } from 'vitest';
+import { UserInfoRetrieve } from './retrieve';
+
+function makeResource(userInfo: UserInfo): IUserInfoResource {
+  return {
+    retrieve: vi.fn(async () => userInfo),
+  };
+}
+
+describe('user-info retrieve component', () => {
+  it('renders finite Agent Wallet limits and step-up status', async () => {
+    const resource = makeResource({
+      email: 'jane@example.com',
+      name: 'Jane Doe',
+      phone: '+15555550123',
+      agent_wallet_spend_limits: {
+        per_transaction: { limit: 50000 },
+        daily: { limit: 500000, used: 120000, remaining: 380000 },
+        thirty_day: {
+          limit: 2000000,
+          used: 600000,
+          remaining: 1400000,
+        },
+      },
+      agent_wallet_step_up: { status: 'identity_verification' },
+    });
+
+    const { lastFrame } = render(
+      <UserInfoRetrieve resource={resource} onComplete={() => {}} />,
+    );
+
+    await vi.waitFor(() => {
+      const frame = lastFrame();
+      expect(frame).toContain('Agent Wallet Spend Limits');
+      expect(frame).toContain('Per-transaction: 50000 cents');
+      expect(frame).toContain(
+        'Daily: limit 500000 cents, used 120000 cents, remaining 380000 cents',
+      );
+      expect(frame).toContain(
+        '30-day: limit 2000000 cents, used 600000 cents, remaining 1400000 cents',
+      );
+      expect(frame).toContain(
+        'Agent Wallet step-up status: identity_verification',
+      );
+    });
+  });
+
+  it('renders unlimited limits while preserving numeric usage', async () => {
+    const resource = makeResource({
+      agent_wallet_spend_limits: {
+        per_transaction: { limit: null },
+        daily: { limit: null, used: 0, remaining: null },
+        thirty_day: { limit: null, used: 12500, remaining: null },
+      },
+    });
+
+    const { lastFrame } = render(
+      <UserInfoRetrieve resource={resource} onComplete={() => {}} />,
+    );
+
+    await vi.waitFor(() => {
+      const frame = lastFrame();
+      expect(frame).toContain('Per-transaction: Unlimited');
+      expect(frame).toContain('Daily: limit Unlimited, used 0 cents');
+      expect(frame).toContain('remaining Unlimited');
+      expect(frame).toContain('30-day: limit Unlimited, used 12500 cents');
+    });
+  });
+
+  it('omits Agent Wallet output when enrichment is absent', async () => {
+    const resource = makeResource({
+      email: 'jane@example.com',
+      name: 'Jane Doe',
+      phone: '+15555550123',
+    });
+
+    const { lastFrame } = render(
+      <UserInfoRetrieve resource={resource} onComplete={() => {}} />,
+    );
+
+    await vi.waitFor(() => {
+      const frame = lastFrame();
+      expect(frame).toContain('jane@example.com');
+      expect(frame).not.toContain('Agent Wallet');
+    });
+  });
+
+  it('renders independently available step-up enrichment', async () => {
+    const resource = makeResource({
+      agent_wallet_step_up: { status: 'not_required' },
+    });
+
+    const { lastFrame } = render(
+      <UserInfoRetrieve resource={resource} onComplete={() => {}} />,
+    );
+
+    await vi.waitFor(() => {
+      const frame = lastFrame();
+      expect(frame).toContain('Agent Wallet step-up status: not_required');
+      expect(frame).not.toContain('Agent Wallet Spend Limits');
+    });
+  });
+});

--- a/packages/cli/src/commands/user-info/retrieve.tsx
+++ b/packages/cli/src/commands/user-info/retrieve.tsx
@@ -10,6 +10,10 @@ interface UserInfoRetrieveProps {
   onComplete: (result: UserInfo | null) => void;
 }
 
+function formatLimit(value: number | null): string {
+  return value === null ? 'Unlimited' : `${value} cents`;
+}
+
 export const UserInfoRetrieve: React.FC<UserInfoRetrieveProps> = ({
   resource,
   onComplete,
@@ -52,6 +56,49 @@ export const UserInfoRetrieve: React.FC<UserInfoRetrieveProps> = ({
           <Text dimColor>Phone: </Text>
           {userInfo?.phone ?? <Text dimColor>Not set</Text>}
         </Text>
+        {userInfo?.agent_wallet_spend_limits && (
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold>Agent Wallet Spend Limits</Text>
+            <Box flexDirection="column" paddingLeft={2}>
+              <Text>
+                <Text dimColor>Per-transaction: </Text>
+                {formatLimit(
+                  userInfo.agent_wallet_spend_limits.per_transaction.limit,
+                )}
+              </Text>
+              <Text>
+                <Text dimColor>Daily: </Text>
+                limit{' '}
+                {formatLimit(userInfo.agent_wallet_spend_limits.daily.limit)},
+                used {userInfo.agent_wallet_spend_limits.daily.used} cents,
+                remaining{' '}
+                {formatLimit(
+                  userInfo.agent_wallet_spend_limits.daily.remaining,
+                )}
+              </Text>
+              <Text>
+                <Text dimColor>30-day: </Text>
+                limit{' '}
+                {formatLimit(
+                  userInfo.agent_wallet_spend_limits.thirty_day.limit,
+                )}
+                , used {userInfo.agent_wallet_spend_limits.thirty_day.used}{' '}
+                cents, remaining{' '}
+                {formatLimit(
+                  userInfo.agent_wallet_spend_limits.thirty_day.remaining,
+                )}
+              </Text>
+            </Box>
+          </Box>
+        )}
+        {userInfo?.agent_wallet_step_up && (
+          <Box marginTop={1}>
+            <Text>
+              <Text dimColor>Agent Wallet step-up status: </Text>
+              {userInfo.agent_wallet_step_up.status}
+            </Text>
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/packages/cli/src/commands/user-info/schema.ts
+++ b/packages/cli/src/commands/user-info/schema.ts
@@ -1,2 +1,3 @@
 // user-info retrieve has no input options beyond what incur provides.
-// Output is a UserInfo object with optional email, name, and phone fields.
+// Output is a UserInfo object with optional identity fields and optional
+// agent_wallet_spend_limits and agent_wallet_step_up enrichment objects.

--- a/packages/sdk/src/resources/__tests__/user-info.test.ts
+++ b/packages/sdk/src/resources/__tests__/user-info.test.ts
@@ -68,6 +68,71 @@ describe('UserInfoResource', () => {
     });
   });
 
+  it('preserves Agent Wallet spend limits and step-up status', async () => {
+    const agentWalletSpendLimits = {
+      per_transaction: { limit: 50000 },
+      daily: { limit: 500000, used: 120000, remaining: 380000 },
+      thirty_day: {
+        limit: 2000000,
+        used: 600000,
+        remaining: 1400000,
+      },
+    };
+    const agentWalletStepUp = { status: 'identity_verification' };
+    mockFetchResponse(200, {
+      email: 'user@example.com',
+      name: 'Test User',
+      first_name: 'Test',
+      last_name: 'User',
+      phone: '+15551234567',
+      agent_wallet_spend_limits: agentWalletSpendLimits,
+      agent_wallet_step_up: agentWalletStepUp,
+    });
+
+    const result = await resource.retrieve();
+
+    expect(result).toEqual({
+      email: 'user@example.com',
+      name: 'Test User',
+      first_name: 'Test',
+      last_name: 'User',
+      phone: '+15551234567',
+      agent_wallet_spend_limits: agentWalletSpendLimits,
+      agent_wallet_step_up: agentWalletStepUp,
+    });
+  });
+
+  it('preserves unlimited limits and numeric usage', async () => {
+    mockFetchResponse(200, {
+      agent_wallet_spend_limits: {
+        per_transaction: { limit: null },
+        daily: { limit: null, used: 0, remaining: null },
+        thirty_day: { limit: null, used: 12345, remaining: null },
+      },
+    });
+
+    const result = await resource.retrieve();
+
+    expect(result.agent_wallet_spend_limits).toEqual({
+      per_transaction: { limit: null },
+      daily: { limit: null, used: 0, remaining: null },
+      thirty_day: { limit: null, used: 12345, remaining: null },
+    });
+  });
+
+  it('keeps independently omitted enrichment fields undefined', async () => {
+    mockFetchResponse(200, {
+      email: 'user@example.com',
+      agent_wallet_step_up: { status: 'not_required' },
+    });
+
+    const result = await resource.retrieve();
+
+    expect(result.agent_wallet_spend_limits).toBeUndefined();
+    expect(result.agent_wallet_step_up).toEqual({ status: 'not_required' });
+    expect(result).not.toHaveProperty('agent_wallet_spend_limits');
+  });
+
   it('handles null fields gracefully', async () => {
     mockFetchResponse(200, {
       email: null,
@@ -100,6 +165,10 @@ describe('UserInfoResource', () => {
       last_name: null,
       phone: null,
     });
+    expect(result.agent_wallet_spend_limits).toBeUndefined();
+    expect(result.agent_wallet_step_up).toBeUndefined();
+    expect(result).not.toHaveProperty('agent_wallet_spend_limits');
+    expect(result).not.toHaveProperty('agent_wallet_step_up');
   });
 
   it('refreshes the token and retries once on 401', async () => {

--- a/packages/sdk/src/resources/user-info.ts
+++ b/packages/sdk/src/resources/user-info.ts
@@ -4,6 +4,30 @@ import type { IUserInfoResource } from '@/resources/interfaces';
 import type { UserInfo } from '@/types/index';
 import { z } from 'zod';
 
+const rollingSpendLimitSchema = z.object({
+  limit: z.number().int().nullable(),
+  used: z.number().int(),
+  remaining: z.number().int().nullable(),
+});
+
+const agentWalletSpendLimitsSchema = z.object({
+  per_transaction: z.object({
+    limit: z.number().int().nullable(),
+  }),
+  daily: rollingSpendLimitSchema,
+  thirty_day: rollingSpendLimitSchema,
+});
+
+const agentWalletStepUpSchema = z.object({
+  status: z.enum([
+    'not_required',
+    'ssn_verification',
+    'identity_verification',
+    'contact_support',
+    'complete',
+  ]),
+});
+
 const userInfoSchema = z
   .looseObject({
     email: z.string().nullable().optional(),
@@ -11,14 +35,30 @@ const userInfoSchema = z
     first_name: z.string().nullable().optional(),
     last_name: z.string().nullable().optional(),
     phone: z.string().nullable().optional(),
+    agent_wallet_spend_limits: agentWalletSpendLimitsSchema.optional(),
+    agent_wallet_step_up: agentWalletStepUpSchema.optional(),
   })
-  .transform(({ email, name, first_name, last_name, phone }) => ({
-    email: email ?? null,
-    name: name ?? null,
-    first_name: first_name ?? null,
-    last_name: last_name ?? null,
-    phone: phone ?? null,
-  }));
+  .transform(
+    ({
+      email,
+      name,
+      first_name,
+      last_name,
+      phone,
+      agent_wallet_spend_limits,
+      agent_wallet_step_up,
+    }) => ({
+      email: email ?? null,
+      name: name ?? null,
+      first_name: first_name ?? null,
+      last_name: last_name ?? null,
+      phone: phone ?? null,
+      ...(agent_wallet_spend_limits === undefined
+        ? {}
+        : { agent_wallet_spend_limits }),
+      ...(agent_wallet_step_up === undefined ? {} : { agent_wallet_step_up }),
+    }),
+  );
 
 export class UserInfoResource
   extends BaseResource

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -176,12 +176,41 @@ export interface BankAccountDetails {
   bank_name?: string;
 }
 
+export type AgentWalletStepUpStatus =
+  | 'not_required'
+  | 'ssn_verification'
+  | 'identity_verification'
+  | 'contact_support'
+  | 'complete';
+
+export interface AgentWalletSpendLimits {
+  per_transaction: {
+    limit: number | null;
+  };
+  daily: {
+    limit: number | null;
+    used: number;
+    remaining: number | null;
+  };
+  thirty_day: {
+    limit: number | null;
+    used: number;
+    remaining: number | null;
+  };
+}
+
+export interface AgentWalletStepUp {
+  status: AgentWalletStepUpStatus;
+}
+
 export interface UserInfo {
   email?: string | null;
   name?: string | null;
   first_name?: string | null;
   last_name?: string | null;
   phone?: string | null;
+  agent_wallet_spend_limits?: AgentWalletSpendLimits;
+  agent_wallet_step_up?: AgentWalletStepUp;
 }
 
 export interface ProductCapability {

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -114,6 +114,8 @@ Always check the current authentication status before starting a new login flow 
 
 If the user is already authenticated but you need broader access (an additional `scope`, `--source-actions`, or `--authorization-detail`), use `auth upgrade` instead of `auth login`. It takes the same flags but, rather than stopping with an "already logged in" message, merges what you request with the current `scope`/`authorization_details` and starts a new approval for the superset — so existing access is never dropped. Check `auth status` first so you know what's already granted. The current session stays valid during the approval and is only replaced once the user approves the new one, so an abandoned upgrade leaves the existing session working.
 
+Optionally, before a purchase, run `link-cli user-info retrieve --format json` to inspect any available Agent Wallet spend limits and step-up status. Finite limit values are cents, while `null` limit or remaining values mean unlimited. Either Agent Wallet object may be absent when enrichment is unavailable; treat this preflight as informational, not as permission or denial to purchase. Spend-request responses and their existing `requires_action` behavior remain authoritative.
+
 ### Step 2: Evaluate the merchant site BEFORE creating a spend request
 
 **CRITICAL:** Before calling `spend-request create` you must complete this checklist:


### PR DESCRIPTION
Surface user's agent wallet spend limits (per_transaction, daily and rolling 30-day) and their step-up status (not_required, ssn_verification, identity_verification, contact_support, and complete) for agentic payments functionality

<img width="1732" height="844" alt="Screenshot 2026-09-04 at 3 06 02 PM_redacted" src="https://github.com/user-attachments/assets/472ebd7f-0f41-4ddc-a7ff-25b952340311" />
