### PR TITLE
fix: Remove explicit frontend amount validation

### DIFF
--- a/.changeset/few-kings-deny.md
+++ b/.changeset/few-kings-deny.md
@@ -1,0 +1,5 @@
+---
+"@stripe/link-cli": minor
+---
+
+Remove explicit CLI-side amount validation

--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -30,7 +30,6 @@ export const createOptions = z.object({
     .number()
     .int()
     .positive()
-    .max(500000)
     .describe('Amount in cents'),
   currency: z.string().length(3).default('usd').describe('Currency code'),
   merchantName: z


### PR DESCRIPTION
Remove explicit schema amount validation and just completely delegate to the backend.

(being blocked is expected here, we just want to verify we aren't blocked on the frontend)

<img width="1300" height="126" alt="Screenshot 2026-09-08 at 11 50 11 AM" src="https://github.com/user-attachments/assets/6063d47f-0abe-4cc7-b0c1-4a34df1c2474" />
