### PR TITLE
fix: prevent hoisted spinner React mismatch in Bun installs

### DIFF
--- a/.changeset/fix-hoisted-spinner.md
+++ b/.changeset/fix-hoisted-spinner.md
@@ -1,0 +1,5 @@
+---
+'@stripe/link-cli': patch
+---
+
+Bundle ink-spinner so interactive commands use the CLI's React and Ink instances, avoiding invalid hook calls when a Bun global install hoists the spinner alongside a different React version.

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
   clean: true,
   sourcemap: false,
   external: ['update-notifier'],
+  // Keep the spinner's React/Ink imports in the CLI's dependency scope when hoisted.
+  noExternal: ['ink-spinner'],
   banner: { js: '#!/usr/bin/env node' },
   define: {
     __CLI_VERSION__: JSON.stringify(pkg.version),

--- a/scripts/test-bun-install.mjs
+++ b/scripts/test-bun-install.mjs
@@ -1,0 +1,113 @@
+// Packaging regression: pnpm run build && node scripts/test-bun-install.mjs
+// Optional argument: an existing CLI tarball (to test a pre-fix build).
+import assert from 'node:assert/strict';
+import { execFileSync, spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const temp = mkdtempSync(join(tmpdir(), 'link-bun-spinner-'));
+try {
+  const tarball = process.argv[2]
+    ? resolve(process.argv[2])
+    : join(temp, 'cli.tgz');
+  if (!process.argv[2]) {
+    execFileSync('pnpm', ['pack', '--out', tarball], {
+      cwd: fileURLToPath(new URL('../packages/cli/', import.meta.url)),
+      stdio: 'inherit',
+    });
+  }
+  // Recreate a shared global dependency layout without changing the user's tools.
+  writeFileSync(join(temp, 'package.json'), '{"private":true,"type":"module"}');
+  execFileSync(
+    'bun',
+    [
+      'add',
+      '--ignore-scripts',
+      tarball,
+      'react@19.2.7',
+      'ink@6.8.0',
+      'ink-spinner@5.0.0',
+    ],
+    {
+      cwd: temp,
+      stdio: 'inherit',
+    },
+  );
+  const entry = join(temp, 'node_modules/@stripe/link-cli/dist/cli.js');
+  const child = spawn(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      `
+    import { createRequire } from 'node:module';
+    import assert from 'node:assert/strict';
+    const cliRequire = createRequire(${JSON.stringify(entry)});
+    const spinnerRequire = createRequire(cliRequire.resolve('ink-spinner'));
+    assert.notEqual(cliRequire.resolve('react'), spinnerRequire.resolve('react'));
+    // Exercise the real interactive command without a terminal or real wallet.
+    process.stdout.isTTY = true;
+    process.stdin.isTTY = true;
+    process.stdin.setRawMode = () => {};
+    globalThis.fetch = (url) => String(url).startsWith('http://127.0.0.1:1')
+      ? new Promise(() => {})
+      : Promise.reject(new Error('Network disabled for packaging test'));
+    process.argv = [process.execPath, ${JSON.stringify(entry)}, 'onboard'];
+    await import(${JSON.stringify(pathToFileURL(entry).href)});
+  `,
+    ],
+    {
+      cwd: temp,
+      env: {
+        ...process.env,
+        LINK_AUTH_FILE: join(temp, 'auth.json'),
+        LINK_ACCESS_TOKEN: '',
+        LINK_REFRESH_TOKEN: '',
+        // Defense in depth: never contact Link, even if a fetch path changes.
+        LINK_AUTH_BASE_URL: 'http://127.0.0.1:1',
+        LINK_API_BASE_URL: 'http://127.0.0.1:1',
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    },
+  );
+  let output = '';
+  let rendered;
+  const timeout = setTimeout(() => child.kill('SIGKILL'), 30_000);
+  function collect(chunk) {
+    output += chunk;
+    // Let the spinner tick before stopping this intentionally pending login.
+    if (!rendered && output.includes('Initiating authentication')) {
+      rendered = setTimeout(() => child.kill('SIGTERM'), 500);
+    }
+  }
+  child.stdout.on('data', collect);
+  child.stderr.on('data', collect);
+  let exitSignal;
+  try {
+    exitSignal = await new Promise((resolve, reject) => {
+      child.on('error', reject);
+      child.on('close', (_code, signal) => resolve(signal));
+    });
+  } finally {
+    clearTimeout(timeout);
+    clearTimeout(rendered);
+  }
+  assert.doesNotMatch(
+    output,
+    /Invalid hook call|Cannot read properties|AssertionError/,
+    output,
+  );
+  assert.match(output, /Initiating authentication/, output);
+  assert.equal(
+    exitSignal,
+    'SIGTERM',
+    `CLI exited before the spinner check: ${output}`,
+  );
+  console.log(
+    'PASS: onboard renders its spinner with a conflicting hoisted React installed.',
+  );
+} finally {
+  rmSync(temp, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Summary

Fix `link-cli onboard` crashing with `Invalid hook call` / `Cannot read properties of null (reading 'useState')` after a Bun global install. The same spinner is used by other interactive commands.

In the affected installation (macOS, Bun 1.3.14, CLI 0.18.0), Ink resolves the CLI's nested React 18.3.1, while the hoisted `ink-spinner` resolves global React 19.2.7. The spinner's hooks therefore use a different React instance from the renderer. This depends on the installed dependency layout; a clean install will not necessarily reproduce it.

- Bundle `ink-spinner` through tsup's `noExternal` option, keeping its React/Ink imports in the CLI's dependency scope. React and Ink themselves remain external.
- Add an opt-in packaging regression script that installs the packed CLI with Bun alongside React 19, Ink 6, and a hoisted spinner, then exercises the real onboarding spinner. It asserts the conflicting React resolution exists, uses a temporary auth file, disables command network requests, and stops before authentication/payment.
- Include a patch changeset. No command, flag, or schema changes.

## Validation

- Reproduced the exact `useState` crash with the pre-fix tarball; the patched tarball passes the same check.
- `pnpm turbo run build typecheck` — passed.
- `pnpm biome check .` — passed.
- CLI Vitest suite — 322 tests passed; SDK Vitest suite — 137 tests passed (isolated HOME to protect local credentials).
- `node scripts/test-bun-install.mjs` — passed. Requires Bun and pnpm; intentionally opt-in, not part of the regular offline unit suite.
- Installed the patched tarball globally using Bun and confirmed onboarding no longer crashes on the reporting machine.

- Go SDK checks — formatting clean, `go mod tidy -diff`, `go vet ./...`, and `go test -race ./...` all passed (Go 1.27.1).

Validation covers the interactive startup regression, not end-to-end payment processing.

To repeat the packaging check:

```sh
pnpm install --frozen-lockfile
pnpm turbo run build
node scripts/test-bun-install.mjs
# To verify the regression against an older build:
node scripts/test-bun-install.mjs /path/to/pre-fix-cli.tgz
```

This is separate from #298 (Bun automatically starting a server from the default export); this PR does not address that hang.

