### PR TITLE
Surface SpendRequest idempotency key

### DIFF
--- a/.changeset/tidy-spend-requests.md
+++ b/.changeset/tidy-spend-requests.md
@@ -1,0 +1,6 @@
+---
+'@stripe/link-cli': patch
+'@stripe/link-sdk': patch
+---
+
+Add caller-supplied idempotency keys to SpendRequest creation.

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -241,6 +241,8 @@ describe('production mode', () => {
         'create',
         '--payment-method-id',
         'pd_prod_test',
+        '--idempotency-key',
+        '550e8400-e29b-41d4-a716-446655440000',
         '--merchant-name',
         'Test Merchant',
         '--merchant-url',
@@ -267,6 +269,9 @@ describe('production mode', () => {
 
       const sentBody = JSON.parse(lastRequest.body);
       expect(sentBody.payment_details).toBe('pd_prod_test');
+      expect(sentBody.idempotency_key).toBe(
+        '550e8400-e29b-41d4-a716-446655440000',
+      );
       expect(sentBody.amount).toBe(5000);
       expect(sentBody.merchant_name).toBe('Test Merchant');
       expect(sentBody.line_items).toEqual([
@@ -275,6 +280,55 @@ describe('production mode', () => {
       expect(sentBody.totals).toEqual([
         { type: 'total', display_text: 'Total', amount: 5000 },
       ]);
+      expect(result.stdout + result.stderr).not.toContain(
+        '550e8400-e29b-41d4-a716-446655440000',
+      );
+    });
+
+    it('omits idempotency_key when --idempotency-key is absent', async () => {
+      const result = await runProdCli(
+        'spend-request',
+        'create',
+        '--merchant-name',
+        'Test Merchant',
+        '--merchant-url',
+        'https://example.com',
+        '--context',
+        VALID_CONTEXT,
+        '--amount',
+        '5000',
+        '--no-request-approval',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(lastRequest.body).idempotency_key).toBeUndefined();
+    });
+
+    it.each([
+      ['', 'must not be empty'],
+      ['a'.repeat(256), 'at most 255 UTF-8 bytes'],
+      ['é'.repeat(128), 'at most 255 UTF-8 bytes'],
+    ])('rejects invalid idempotency key %#', async (key, expectedMessage) => {
+      const result = await runProdCli(
+        'spend-request',
+        'create',
+        '--idempotency-key',
+        key,
+        '--merchant-name',
+        'Test Merchant',
+        '--merchant-url',
+        'https://example.com',
+        '--context',
+        VALID_CONTEXT,
+        '--amount',
+        '5000',
+        '--json',
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain(expectedMessage);
+      expect(requests).toHaveLength(0);
     });
 
     it('returns the API response as JSON output', async () => {
@@ -392,6 +446,8 @@ describe('production mode', () => {
         'create',
         '--payment-method-id',
         'pd_prod_test',
+        '--idempotency-key',
+        'delegated-key',
         '--execution-method',
         'link_pay_token',
         '--merchant-account-id',
@@ -411,6 +467,7 @@ describe('production mode', () => {
 
       const sentBody = JSON.parse(lastRequest.body);
       expect(sentBody).toMatchObject({
+        idempotency_key: 'delegated-key',
         payment_details: 'pd_prod_test',
         credential_type: 'card',
         execution_method: 'link_pay_token',
@@ -820,10 +877,13 @@ describe('production mode', () => {
 
     it('surfaces API error messages', async () => {
       setNextResponse(422, { error: { message: 'Invalid payment details' } });
+      const idempotencyKey = 'error-path-key-that-must-not-be-echoed';
 
       const result = await runProdCli(
         'spend-request',
         'create',
+        '--idempotency-key',
+        idempotencyKey,
         '--payment-method-id',
         'pd_bad',
         '-m',
@@ -844,6 +904,7 @@ describe('production mode', () => {
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
       expect(output).toContain('Invalid payment details');
+      expect(output).not.toContain(idempotencyKey);
     });
 
     it('surfaces the duplicate spend request on spend_request_rate_limited error', async () => {

--- a/packages/cli/src/commands/spend-request/index.tsx
+++ b/packages/cli/src/commands/spend-request/index.tsx
@@ -254,6 +254,7 @@ export function createSpendRequestCli(
       }
 
       const createParams = {
+        idempotency_key: opts.idempotencyKey,
         payment_details: opts.paymentMethodId,
         credential_type: credentialType,
         network_id: networkId,

--- a/packages/cli/src/commands/spend-request/schema.ts
+++ b/packages/cli/src/commands/spend-request/schema.ts
@@ -1,6 +1,16 @@
 import { z } from 'incur';
 
 export const createOptions = z.object({
+  idempotencyKey: z
+    .string()
+    .min(1, 'Idempotency key must not be empty')
+    .refine((key) => new TextEncoder().encode(key).length <= 255, {
+      message: 'Idempotency key must be at most 255 UTF-8 bytes',
+    })
+    .optional()
+    .describe(
+      'Opaque, non-sensitive value to reuse only when retrying the same logical creation',
+    ),
   paymentMethodId: z.string().optional().describe('Payment method ID'),
   credentialType: z
     .enum(['shared_payment_token', 'card'])

--- a/packages/sdk-go/CHANGELOG.md
+++ b/packages/sdk-go/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ## Unreleased
 
+- Add optional idempotency keys to SpendRequest creation.
 - Initial Go SDK implementation.

--- a/packages/sdk-go/client_test.go
+++ b/packages/sdk-go/client_test.go
@@ -231,6 +231,55 @@ func TestExplicitEmptyCollectionsAreSent(t *testing.T) {
 	}
 }
 
+func TestCreateSpendRequestIdempotencyKeyEncoding(t *testing.T) {
+	key := "550e8400-e29b-41d4-a716-446655440000"
+	tests := []struct {
+		name    string
+		key     *string
+		present bool
+	}{
+		{name: "present", key: &key, present: true},
+		{name: "omitted", key: nil, present: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data, err := json.Marshal(CreateSpendRequestParams{
+				Context:        "A sufficiently detailed context for testing idempotency key encoding.",
+				IdempotencyKey: test.key,
+			})
+			assertNoError(t, err)
+			var fields map[string]json.RawMessage
+			assertNoError(t, json.Unmarshal(data, &fields))
+			encoded, ok := fields["idempotency_key"]
+			if ok != test.present {
+				t.Fatalf("idempotency_key presence was %t, want %t: %s", ok, test.present, data)
+			}
+			if test.present && string(encoded) != `"550e8400-e29b-41d4-a716-446655440000"` {
+				t.Fatalf("got idempotency_key %s", encoded)
+			}
+		})
+	}
+}
+
+func TestCreateSpendRequestIncompleteIdempotentRequestReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.WriteHeader(http.StatusConflict)
+		_, _ = response.Write([]byte(`{"error":{"message":"The keyed creation is still in progress"}}`))
+	}))
+	defer server.Close()
+	client, err := NewClient(Options{AccessToken: "token", SpendRequestBaseURL: server.URL})
+	assertNoError(t, err)
+	key := "incomplete-key"
+	_, err = client.SpendRequests.Create(context.Background(), CreateSpendRequestParams{
+		Context:        "A sufficiently detailed context for testing an incomplete keyed creation.",
+		IdempotencyKey: &key,
+	})
+	var apiError *LinkAPIError
+	if !errors.As(err, &apiError) || apiError.Status != http.StatusConflict {
+		t.Fatalf("got %#v, want LinkAPIError with status 409", err)
+	}
+}
+
 func TestExplicitEmptyCollectionsMarshalAcrossRequestTypes(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/packages/sdk-go/params.go
+++ b/packages/sdk-go/params.go
@@ -12,6 +12,7 @@ const ExecutionMethodLinkPayToken ExecutionMethod = "link_pay_token"
 
 // CreateSpendRequestParams contains fields accepted when creating a spend request.
 type CreateSpendRequestParams struct {
+	IdempotencyKey   *string           `json:"idempotency_key,omitempty"`
 	PaymentDetails    *string           `json:"payment_details,omitempty"`
 	CredentialType    *CredentialType   `json:"credential_type,omitempty"`
 	NetworkID         *string           `json:"network_id,omitempty"`

--- a/packages/sdk-go/params.go
+++ b/packages/sdk-go/params.go
@@ -12,7 +12,7 @@ const ExecutionMethodLinkPayToken ExecutionMethod = "link_pay_token"
 
 // CreateSpendRequestParams contains fields accepted when creating a spend request.
 type CreateSpendRequestParams struct {
-	IdempotencyKey   *string           `json:"idempotency_key,omitempty"`
+	IdempotencyKey    *string           `json:"idempotency_key,omitempty"`
 	PaymentDetails    *string           `json:"payment_details,omitempty"`
 	CredentialType    *CredentialType   `json:"credential_type,omitempty"`
 	NetworkID         *string           `json:"network_id,omitempty"`

--- a/packages/sdk/src/resources/__tests__/spend-request.test.ts
+++ b/packages/sdk/src/resources/__tests__/spend-request.test.ts
@@ -187,6 +187,32 @@ describe('SpendRequestResource', () => {
       });
     });
 
+    it('serializes idempotency_key in the normal create body', async () => {
+      mockFetchResponse(200, spendRequestResponse);
+
+      await repo.create({
+        ...validParams,
+        idempotency_key: '550e8400-e29b-41d4-a716-446655440000',
+      });
+
+      const [url, opts] = mockFetch.mock.calls[0]!;
+      const sentBody = JSON.parse(opts.body);
+      expect(url).toBe('https://api.link.com/spend_requests');
+      expect(sentBody.idempotency_key).toBe(
+        '550e8400-e29b-41d4-a716-446655440000',
+      );
+    });
+
+    it('does not include idempotency_key when it is omitted', async () => {
+      mockFetchResponse(200, spendRequestResponse);
+
+      await repo.create(validParams);
+
+      const [, opts] = mockFetch.mock.calls[0]!;
+      const sentBody = JSON.parse(opts.body);
+      expect(sentBody.idempotency_key).toBeUndefined();
+    });
+
     it('does not include metadata in POST body when not set', async () => {
       mockFetchResponse(200, spendRequestResponse);
 
@@ -227,12 +253,28 @@ describe('SpendRequestResource', () => {
       await repo.create({
         ...validParams,
         approve: true,
+        idempotency_key: 'delegated-key',
       });
 
       const [url, opts] = mockFetch.mock.calls[0]!;
       expect(url).toBe('https://api.link.com/spend_requests/create_delegated');
       const sentBody = JSON.parse(opts.body);
       expect(sentBody.approve).toBeUndefined();
+      expect(sentBody.idempotency_key).toBe('delegated-key');
+    });
+
+    it('keeps an incomplete keyed creation 409 as a LinkApiError', async () => {
+      mockFetchResponse(409, {
+        error: { message: 'The keyed creation is still in progress' },
+      });
+
+      const error = await repo
+        .create({ ...validParams, idempotency_key: 'incomplete-key' })
+        .catch((cause) => cause);
+
+      expect(error).toBeInstanceOf(LinkApiError);
+      expect(error.status).toBe(409);
+      expect(error.message).toContain('still in progress');
     });
 
     it('sends to /spend_requests when approve is not set', async () => {

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -24,6 +24,7 @@ export type AccessTokenProvider = (
 ) => Promise<string> | string;
 
 export interface CreateSpendRequestParams {
+  idempotency_key?: string;
   payment_details?: string;
   credential_type?: CredentialType;
   network_id?: string;


### PR DESCRIPTION
Adds optional caller-supplied idempotency key to SpendRequest creation. This allows integrations to safely retry requests after timeouts or ambiguous failures without unintentionally creating duplicate SpendRequests. Reusing a key returns the original completed request, while omitting it preserves existing behaviour


<img width="1107" height="866" alt="Screenshot 2026-09-10 at 7 48 37 PM-redacted" src="https://github.com/user-attachments/assets/37bb922f-839c-4469-b8bf-22f33f9e8ee8" />
