### PR TITLE
fix: prevent Bun from auto-serving the CLI entrypoint

### DIFF
--- a/.changeset/fix-bun-cli-auto-serve.md
+++ b/.changeset/fix-bun-cli-auto-serve.md
@@ -1,0 +1,5 @@
+---
+'@stripe/link-cli': patch
+---
+
+Prevent Bun from automatically starting an HTTP server after CLI commands finish by removing the CLI entrypoint's default fetch-bearing export. Explicit HTTP serving remains available through `serve`.

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -172,6 +172,6 @@ cli.command(
 );
 cli.command(createServeCli(cli));
 
+// Bun auto-starts an HTTP server for default exports with a fetch method.
+// This is a CLI entrypoint; HTTP serving must go through the explicit serve command.
 cli.serve();
-
-export default cli;


### PR DESCRIPTION
## Summary

Fixes #298.

Bun automatically starts an HTTP server when an entrypoint default-exports an object with a `fetch` method. The CLI's default export triggers this after ordinary commands print their output, contaminating stdout and keeping the process alive.

Remove that default export while keeping `cli.serve()` and the explicit `serve` command unchanged. Include a patch changeset.

## Validation

- Reproduced on Bun 1.3.14: `bun packages/cli/dist/cli.js --version` printed the version followed by `Started development server` and did not exit; Node exited normally. The patched build exits cleanly on both runtimes.
- Packed and installed the patched CLI in an isolated Bun installation. Both `bunx` and `bunx --bun` returned parseable auth-status JSON and exited normally (temporary auth storage and a fake environment token; `--interval 1` skips the update check).
- Verified stdio MCP initialization and explicit HTTP `serve` on Node and Bun. HTTP MCP initialization succeeds; arbitrary command paths remain blocked with 404.
- Existing CLI suite: 326 tests passed. TypeScript SDK suite: 142 tests passed.
- Build, typecheck, Biome, and Go SDK formatting, module tidy, vet, and race tests passed.

No command, flag, or schema changes. This is separate from the spinner dependency fix in #312.
