### PR TITLE
Report all agent payment attempts

### DIFF
--- a/.changeset/report-all-agent-attempts.md
+++ b/.changeset/report-all-agent-attempts.md
@@ -1,0 +1,5 @@
+---
+'@stripe/link-cli': patch
+---
+
+Tell purchasing agents to report every payment attempt, including failures that happen before a spend request is created.

--- a/plugins/cursor-link/skills/complete-link-purchase/SKILL.md
+++ b/plugins/cursor-link/skills/complete-link-purchase/SKILL.md
@@ -124,16 +124,17 @@ user's default address unless they chose another.
 
 ### Step 6: Report the outcome
 
-Call `report_agent_observation` with the merchant `domain`, an `outcome` of
-`success`, `blocked`, or `abandoned`, and the `spend_request_id`. Add `tags`
-from Link's fixed vocabulary — `captcha`, `waf_block`, `cdn_block`,
-`rate_limited`, `login_required`, `3ds_challenge`, `payment_declined`,
-`site_error`, `timeout`, `page_inaccessible`, `anti_bot_script`,
-`stripe_checkout`, `other` — plus `step` and `freeform_context` where they add
-detail.
+Call `report_agent_observation` after every purchase attempt with the merchant
+`domain` and an `outcome` of `success`, `blocked`, or `abandoned`. Include the
+`spend_request_id` when one was created. Add `tags` from Link's fixed vocabulary
+— `captcha`, `waf_block`, `cdn_block`, `rate_limited`, `login_required`,
+`3ds_challenge`, `payment_declined`, `site_error`, `timeout`,
+`page_inaccessible`, `anti_bot_script`, `stripe_checkout`, `other` — plus
+`step` and `freeform_context` where they add detail.
 
 This is telemetry that improves checkout for agents. It does not change the
-spend request. Report failures too; they are the useful ones.
+spend request. Report failures too, including attempts that fail before a spend
+request is created; they are the useful ones.
 
 ## Handling credentials
 

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -359,13 +359,13 @@ All errors are output as JSON with `code` and `message` fields, with exit code 1
 
 ## Reporting outcomes
 
-After a purchase attempt, you're encouraged to report the outcome — whether it succeeded, was blocked, or was abandoned. This is optional but helps Stripe improve checkout for agents.
+After every purchase attempt, report the outcome — whether it succeeded, was blocked, or was abandoned. Include attempts that fail before a spend request is created; omit `--spend-request-id` when there is no ID. This helps Stripe improve checkout for agents.
 
 ```bash
 link-cli report \
   --domain <merchant-domain> \
   --outcome <success|blocked|abandoned> \
-  --spend-request-id <lsrq_...> \
+  [--spend-request-id <lsrq_...>] \
   [--tag <tag>] \
   [--step <step>] \
   [--freeform-context "<details>"] \
@@ -437,8 +437,8 @@ link-cli report --domain shop.example.com --outcome success --spend-request-id l
 # Blocked by captcha
 link-cli report --domain shop.example.com --outcome blocked --spend-request-id lsrq_abc123 --tag captcha --step "checkout page"
 
-# Abandoned due to site error
-link-cli report --domain shop.example.com --outcome abandoned --spend-request-id lsrq_abc123 --tag site_error --freeform-context "500 error on payment submission"
+# Abandoned before a spend request was created
+link-cli report --domain shop.example.com --outcome abandoned --tag site_error --freeform-context "500 error before checkout loaded"
 
 # Success, with the path recorded for the next agent
 link-cli report --domain shop.example.com --outcome success --spend-request-id lsrq_abc123 \
@@ -452,7 +452,7 @@ EOF
 )"
 ```
 
-Report output is agent-only (not shown to the user). Reporting is encouraged but not required, including when the purchase failed.
+Report output is agent-only (not shown to the user). Report every attempt, including failures that happen before a spend request exists.
 
 ## Further docs
 


### PR DESCRIPTION
## Summary

Update Link purchase skills to tell agents to report every payment attempt, including failures before a spend request is created. The examples now show omitting `spend_request_id` when no request exists.

r?
cc: @drapeau-stripe @melaniecooray-stripe

## Test plan

- Parsed the updated skill and changeset frontmatter as YAML
- Ran `git diff --check`

## Rollout / revert

Ships with the next `@stripe/link-cli` patch release. Revert this PR to restore the previous guidance.
