### PR TITLE
Identity 1/n: attestations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,15 +109,15 @@ Key input field notes:
 
 - `onboard` — Guided setup: authenticates (skips if already logged in), checks payment methods (prompts to add one if missing, shows picker if multiple), shows app download QR code, then runs the full demo. Requires a TTY.
 
-### attestations command (AAP)
+### attestations command
 
 `attestations request --count <n> [--issuer <url>] [--access-token <t>]` — mints Agent Attestation Tokens via the Privacy Pass Blind RSA protocol (token type `0x0002`, RFC 9578 / RFC 9577). Agent-only output. The SDK owns the protocol and API implementation in `packages/sdk/src/resources/attestations.ts` and `attestations-crypto.ts`; CLI schema and registration remain in `packages/cli/src/commands/attestations/`.
 
 - Discovery: `GET <issuer>/.well-known/aap-issuer` → metadata, then `GET` its `token_keys` URL. The issuer and every discovered endpoint must use HTTPS on the same DNS origin; redirects and IP-literal hosts are rejected before credentials are sent.
-- Tokens use the AAP stable challenge: fixed `issuer_name`, empty `redemption_context`, and empty `origin_info`.
+- Tokens use a stable Privacy Pass challenge: fixed `issuer_name`, empty `redemption_context`, and empty `origin_info`.
 - Blind signatures are verified after unblinding before final tokens are returned.
-- Server-side max batch is 100. Issuance does not require an AAP-specific OAuth scope.
-- Auth: `--access-token`, else `AAP_ACCESS_TOKEN`, else stored CLI credentials.
+- Server-side max batch is 100. Issuance does not require an additional OAuth scope.
+- Auth: `--access-token`, else stored CLI credentials.
 
 ### serve command
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Commands in `packages/cli/src/cli.tsx` (incur framework). Each has two output mo
 - **Interactive** (default): Ink/React components from `packages/cli/src/commands/`
 - **JSON** (`--format json`): JSON to stdout, errors as JSON with `code` and `message` fields with exit code 1
 
-Commands: `auth login|logout|status`, `spend-request create|update|retrieve|request-approval|cancel`, `payment-methods list`, `shipping-address list`, `mpp pay|decode`, `attestations request`, `serve`.
+Commands: `auth login|logout|status`, `spend-request create|update|retrieve|request-approval|cancel`, `payment-methods list`, `shipping-address list`, `mpp pay|decode`, `identity attestations request`, `serve`.
 
 The CLI also runs as an MCP server (`--mcp`) and serves skill files via `skills` subcommand, both provided by incur.
 
@@ -109,14 +109,14 @@ Key input field notes:
 
 - `onboard` — Guided setup: authenticates (skips if already logged in), checks payment methods (prompts to add one if missing, shows picker if multiple), shows app download QR code, then runs the full demo. Requires a TTY.
 
-### attestations command
+### identity attestations command
 
 Unlisted: omitted from `--help`, `--llms`, and MCP tool lists unless `LINK_IDENTITY_COMMANDS=1` (or `true`). Even when enabled, the command sets `mcp: false` so MCP clients do not see it.
 
-`attestations request --count <n> [--issuer <url>] [--access-token <t>]` — mints Agent Attestation Tokens via the Privacy Pass Blind RSA protocol (token type `0x0002`, RFC 9578 / RFC 9577). Agent-only output. The SDK owns the protocol and API implementation in `packages/sdk/src/resources/attestations.ts` and `attestations-crypto.ts`; CLI schema and registration remain in `packages/cli/src/commands/attestations/`.
+`identity attestations request --count <n> [--issuer <url>] [--access-token <t>]` — gets privacy-preserving tokens that show Link attests to your agent. Agent-only output. The SDK owns issuance in `packages/sdk/src/resources/attestations.ts` and `attestations-crypto.ts`; CLI schema and registration remain in `packages/cli/src/commands/attestations/`, mounted under `packages/cli/src/commands/identity/`.
 
 - Discovery: `GET <issuer>/.well-known/aap-issuer` → metadata, then `GET` its `token_keys` URL. The issuer and every discovered endpoint must use HTTPS on the same DNS origin; redirects and IP-literal hosts are rejected before credentials are sent.
-- Tokens use a stable Privacy Pass challenge: fixed `issuer_name`, empty `redemption_context`, and empty `origin_info`.
+- Tokens use a stable challenge: fixed `issuer_name`, empty `redemption_context`, and empty `origin_info`.
 - Blind signatures are verified after unblinding before final tokens are returned.
 - Server-side max batch is 100. Issuance does not require an additional OAuth scope.
 - Auth: `--access-token`, else stored CLI credentials.
@@ -162,4 +162,4 @@ JSON output mode (`--format json`) is **not** affected — `JSON.stringify` enco
 | `LINK_API_BASE_URL` | Override API base URL |
 | `LINK_AUTH_BASE_URL` | Override auth base URL |
 | `LINK_HTTP_PROXY` | Route all SDK requests through an HTTP proxy (requires `undici` installed) |
-| `LINK_IDENTITY_COMMANDS` | When `1` or `true`, register the unlisted `attestations` command. Omitted from `--help`, `--llms`, and MCP otherwise. |
+| `LINK_IDENTITY_COMMANDS` | When `1` or `true`, register the unlisted `identity` command group. Omitted from `--help`, `--llms`, and MCP otherwise. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ Key input field notes:
 - Discovery: `GET <issuer>/.well-known/aap-issuer` → metadata, then `GET` its `token_keys` URL. The issuer and every discovered endpoint must use HTTPS on the same DNS origin; redirects and IP-literal hosts are rejected before credentials are sent.
 - Tokens use the AAP stable challenge: fixed `issuer_name`, empty `redemption_context`, and empty `origin_info`.
 - Blind signatures are verified after unblinding before final tokens are returned.
-- Server-side max batch is 100. Issuance requires the `aap:represent` scope.
+- Server-side max batch is 100. Issuance does not require an AAP-specific OAuth scope.
 - Auth: `--access-token`, else `AAP_ACCESS_TOKEN`, else stored CLI credentials.
 
 ### serve command

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ node packages/cli/dist/cli.js <command>
 ### SDK Resources
 
 Defined in `packages/sdk/src/resources/interfaces.ts`:
+- `IAttestationsResource` — Privacy Pass Blind RSA token issuance
 - `ISpendRequestResource` — CRUD + request-approval for spend requests
 
 The SDK only accepts credentials. Device authorization, refresh-token
@@ -50,7 +51,7 @@ Commands in `packages/cli/src/cli.tsx` (incur framework). Each has two output mo
 - **Interactive** (default): Ink/React components from `packages/cli/src/commands/`
 - **JSON** (`--format json`): JSON to stdout, errors as JSON with `code` and `message` fields with exit code 1
 
-Commands: `auth login|logout|status`, `spend-request create|update|retrieve|request-approval|cancel`, `payment-methods list`, `shipping-address list`, `mpp pay|decode`, `serve`.
+Commands: `auth login|logout|status`, `spend-request create|update|retrieve|request-approval|cancel`, `payment-methods list`, `shipping-address list`, `mpp pay|decode`, `attestations request`, `serve`.
 
 The CLI also runs as an MCP server (`--mcp`) and serves skill files via `skills` subcommand, both provided by incur.
 
@@ -107,6 +108,16 @@ Key input field notes:
 ### onboard command
 
 - `onboard` — Guided setup: authenticates (skips if already logged in), checks payment methods (prompts to add one if missing, shows picker if multiple), shows app download QR code, then runs the full demo. Requires a TTY.
+
+### attestations command (AAP)
+
+`attestations request --count <n> [--issuer <url>] [--access-token <t>]` — mints Agent Attestation Tokens via the Privacy Pass Blind RSA protocol (token type `0x0002`, RFC 9578 / RFC 9577). Agent-only output. The SDK owns the protocol and API implementation in `packages/sdk/src/resources/attestations.ts` and `attestations-crypto.ts`; CLI schema and registration remain in `packages/cli/src/commands/attestations/`.
+
+- Discovery: `GET <issuer>/.well-known/aap-issuer` → metadata, then `GET` its `token_keys` URL. The issuer and every discovered endpoint must use HTTPS on the same DNS origin; redirects and IP-literal hosts are rejected before credentials are sent.
+- Tokens use the AAP stable challenge: fixed `issuer_name`, empty `redemption_context`, and empty `origin_info`.
+- Blind signatures are verified after unblinding before final tokens are returned.
+- Server-side max batch is 100. Issuance requires the `aap:represent` scope.
+- Auth: `--access-token`, else `AAP_ACCESS_TOKEN`, else stored CLI credentials.
 
 ### serve command
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ Key input field notes:
 
 ### attestations command
 
+Unlisted: omitted from `--help`, `--llms`, and MCP tool lists unless `LINK_IDENTITY_COMMANDS=1` (or `true`). Even when enabled, the command sets `mcp: false` so MCP clients do not see it.
+
 `attestations request --count <n> [--issuer <url>] [--access-token <t>]` — mints Agent Attestation Tokens via the Privacy Pass Blind RSA protocol (token type `0x0002`, RFC 9578 / RFC 9577). Agent-only output. The SDK owns the protocol and API implementation in `packages/sdk/src/resources/attestations.ts` and `attestations-crypto.ts`; CLI schema and registration remain in `packages/cli/src/commands/attestations/`.
 
 - Discovery: `GET <issuer>/.well-known/aap-issuer` → metadata, then `GET` its `token_keys` URL. The issuer and every discovered endpoint must use HTTPS on the same DNS origin; redirects and IP-literal hosts are rejected before credentials are sent.
@@ -160,3 +162,4 @@ JSON output mode (`--format json`) is **not** affected — `JSON.stringify` enco
 | `LINK_API_BASE_URL` | Override API base URL |
 | `LINK_AUTH_BASE_URL` | Override auth base URL |
 | `LINK_HTTP_PROXY` | Route all SDK requests through an HTTP proxy (requires `undici` installed) |
+| `LINK_IDENTITY_COMMANDS` | When `1` or `true`, register the unlisted `attestations` command. Omitted from `--help`, `--llms`, and MCP otherwise. |

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ link-cli attestations request --count 10
 link-cli attestations request --count 10 --issuer https://api.link.com
 ```
 
-`attestations request` fills an Agent Attestation Token pool using Privacy Pass Blind RSA. It accepts `--count` (1–100), an optional HTTPS `--issuer`, and an optional `--access-token`; no AAP-specific OAuth scope is required. Issuer discovery and issuance endpoints must remain on the issuer's HTTPS DNS origin; redirects and IP-literal hosts are rejected.
+`attestations request` fills an Agent Attestation Token pool using Privacy Pass Blind RSA. It accepts `--count` (1–100), an optional HTTPS `--issuer`, and an optional `--access-token`. Issuer discovery and issuance endpoints must remain on the issuer's HTTPS DNS origin; redirects and IP-literal hosts are rejected.
 
 ### Spend request lifecycle
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ With `--interval`, the login command yields the verification code immediately an
 ```json
 {
   "authenticated": true,
-  "scope": "userinfo:read payment_methods.agentic aap:represent",
+  "scope": "userinfo:read payment_methods.agentic",
   "authorization_details": [{ "type": "source", "actions": ["read"] }],
   "update": {
     "current_version": "0.1.2",
@@ -282,7 +282,7 @@ link-cli attestations request --count 10
 link-cli attestations request --count 10 --issuer https://api.link.com
 ```
 
-`attestations request` fills an Agent Attestation Token pool using Privacy Pass Blind RSA. It accepts `--count` (1–100), an optional HTTPS `--issuer`, and an optional `--access-token`. Issuer discovery and issuance endpoints must remain on the issuer's HTTPS DNS origin; redirects and IP-literal hosts are rejected.
+`attestations request` fills an Agent Attestation Token pool using Privacy Pass Blind RSA. It accepts `--count` (1–100), an optional HTTPS `--issuer`, and an optional `--access-token`; no AAP-specific OAuth scope is required. Issuer discovery and issuance endpoints must remain on the issuer's HTTPS DNS origin; redirects and IP-literal hosts are rejected.
 
 ### Spend request lifecycle
 

--- a/README.md
+++ b/README.md
@@ -275,16 +275,18 @@ Set `NO_UPDATE_NOTIFIER=1` to suppress update checks (for example, in CI).
 
 All commands accept `--auth <path>` to store auth credentials in a specific file instead of the default location. `auth login` writes to this file; all other commands read from it. Useful for running multiple sessions with separate identities.
 
-### Agent attestation tokens
+### Identity
 
-Unlisted command: set `LINK_IDENTITY_COMMANDS=1` to enable it. It is omitted from `--help`, `--llms`, and MCP tool lists otherwise.
+Unlisted commands: set `LINK_IDENTITY_COMMANDS=1` to enable them. They are omitted from `--help`, `--llms`, and MCP tool lists otherwise.
+
+Privacy-preserving tokens that show Link attests to your agent:
 
 ```bash
-LINK_IDENTITY_COMMANDS=1 link-cli attestations request --count 10
-LINK_IDENTITY_COMMANDS=1 link-cli attestations request --count 10 --issuer https://api.link.com
+LINK_IDENTITY_COMMANDS=1 link-cli identity attestations request --count 10
+LINK_IDENTITY_COMMANDS=1 link-cli identity attestations request --count 10 --issuer https://api.link.com
 ```
 
-`attestations request` fills an Agent Attestation Token pool using Privacy Pass Blind RSA. It accepts `--count` (1–100), an optional HTTPS `--issuer`, and an optional `--access-token`. Issuer discovery and issuance endpoints must remain on the issuer's HTTPS DNS origin; redirects and IP-literal hosts are rejected.
+`identity attestations request` asks Link for a pool of those tokens (`--count` 1–100). You can pass an HTTPS `--issuer` and an `--access-token`; otherwise stored login credentials are used. Issuer discovery and issuance stay on the issuer's HTTPS DNS origin; redirects and IP-literal hosts are rejected.
 
 ### Spend request lifecycle
 

--- a/README.md
+++ b/README.md
@@ -277,9 +277,11 @@ All commands accept `--auth <path>` to store auth credentials in a specific file
 
 ### Agent attestation tokens
 
+Unlisted command: set `LINK_IDENTITY_COMMANDS=1` to enable it. It is omitted from `--help`, `--llms`, and MCP tool lists otherwise.
+
 ```bash
-link-cli attestations request --count 10
-link-cli attestations request --count 10 --issuer https://api.link.com
+LINK_IDENTITY_COMMANDS=1 link-cli attestations request --count 10
+LINK_IDENTITY_COMMANDS=1 link-cli attestations request --count 10 --issuer https://api.link.com
 ```
 
 `attestations request` fills an Agent Attestation Token pool using Privacy Pass Blind RSA. It accepts `--count` (1–100), an optional HTTPS `--issuer`, and an optional `--access-token`. Issuer discovery and issuance endpoints must remain on the issuer's HTTPS DNS origin; redirects and IP-literal hosts are rejected.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ With `--interval`, the login command yields the verification code immediately an
 ```json
 {
   "authenticated": true,
-  "scope": "userinfo:read payment_methods.agentic",
+  "scope": "userinfo:read payment_methods.agentic aap:represent",
   "authorization_details": [{ "type": "source", "actions": ["read"] }],
   "update": {
     "current_version": "0.1.2",
@@ -274,6 +274,15 @@ With `--interval`, the login command yields the verification code immediately an
 Set `NO_UPDATE_NOTIFIER=1` to suppress update checks (for example, in CI).
 
 All commands accept `--auth <path>` to store auth credentials in a specific file instead of the default location. `auth login` writes to this file; all other commands read from it. Useful for running multiple sessions with separate identities.
+
+### Agent attestation tokens
+
+```bash
+link-cli attestations request --count 10
+link-cli attestations request --count 10 --issuer https://api.link.com
+```
+
+`attestations request` fills an Agent Attestation Token pool using Privacy Pass Blind RSA. It accepts `--count` (1–100), an optional HTTPS `--issuer`, and an optional `--access-token`. Issuer discovery and issuance endpoints must remain on the issuer's HTTPS DNS origin; redirects and IP-literal hosts are rejected.
 
 ### Spend request lifecycle
 

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1742,7 +1742,9 @@ describe('production mode', () => {
       );
       expect(deviceCodeRequest).toBeDefined();
       const params = new URLSearchParams(deviceCodeRequest?.body);
-      expect(params.get('scope')).toBe('userinfo:read payment_methods.agentic');
+      expect(params.get('scope')).toBe(
+        'userinfo:read payment_methods.agentic aap:represent',
+      );
       expect(params.get('authorization_details')).toBeNull();
       expect(params.getAll('authorization_details[][type]')).toEqual([
         'source',
@@ -1830,7 +1832,9 @@ describe('production mode', () => {
       const params = new URLSearchParams(deviceCodeRequest?.body);
       expect(params.get('client_hint')).toBe('My Agent');
       expect(params.get('connection_label')).toContain('My Agent on ');
-      expect(params.get('scope')).toBe('userinfo:read payment_methods.agentic');
+      expect(params.get('scope')).toBe(
+        'userinfo:read payment_methods.agentic aap:represent',
+      );
 
       // Returns immediately with verification URL and _next hint
       const output = parseJson(result.stdout) as Record<string, unknown>[];

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1742,9 +1742,7 @@ describe('production mode', () => {
       );
       expect(deviceCodeRequest).toBeDefined();
       const params = new URLSearchParams(deviceCodeRequest?.body);
-      expect(params.get('scope')).toBe(
-        'userinfo:read payment_methods.agentic aap:represent',
-      );
+      expect(params.get('scope')).toBe('userinfo:read payment_methods.agentic');
       expect(params.get('authorization_details')).toBeNull();
       expect(params.getAll('authorization_details[][type]')).toEqual([
         'source',
@@ -1832,9 +1830,7 @@ describe('production mode', () => {
       const params = new URLSearchParams(deviceCodeRequest?.body);
       expect(params.get('client_hint')).toBe('My Agent');
       expect(params.get('connection_label')).toContain('My Agent on ');
-      expect(params.get('scope')).toBe(
-        'userinfo:read payment_methods.agentic aap:represent',
-      );
+      expect(params.get('scope')).toBe('userinfo:read payment_methods.agentic');
 
       // Returns immediately with verification URL and _next hint
       const output = parseJson(result.stdout) as Record<string, unknown>[];

--- a/packages/cli/src/auth/__tests__/auth-resource.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-resource.test.ts
@@ -72,9 +72,7 @@ describe('LinkAuthResource', () => {
 
       const body = mockFetch.mock.calls[0][1].body as string;
       const params = new URLSearchParams(body);
-      expect(params.get('scope')).toBe(
-        'userinfo:read payment_methods.agentic aap:represent',
-      );
+      expect(params.get('scope')).toBe('userinfo:read payment_methods.agentic');
     });
 
     it('passes a custom scope when provided', async () => {

--- a/packages/cli/src/auth/__tests__/auth-resource.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-resource.test.ts
@@ -72,7 +72,9 @@ describe('LinkAuthResource', () => {
 
       const body = mockFetch.mock.calls[0][1].body as string;
       const params = new URLSearchParams(body);
-      expect(params.get('scope')).toBe('userinfo:read payment_methods.agentic');
+      expect(params.get('scope')).toBe(
+        'userinfo:read payment_methods.agentic aap:represent',
+      );
     });
 
     it('passes a custom scope when provided', async () => {

--- a/packages/cli/src/auth/__tests__/merge-access.test.ts
+++ b/packages/cli/src/auth/__tests__/merge-access.test.ts
@@ -47,7 +47,9 @@ describe('computeMergedAccess', () => {
       existingAuthorizationDetails: [],
     });
 
-    expect(merged.mergedScope).toBe('userinfo:read payment_methods.agentic');
+    expect(merged.mergedScope).toBe(
+      'userinfo:read payment_methods.agentic aap:represent',
+    );
   });
 
   it('unions source actions across requested and existing (keeps already-granted actions)', () => {

--- a/packages/cli/src/auth/__tests__/merge-access.test.ts
+++ b/packages/cli/src/auth/__tests__/merge-access.test.ts
@@ -47,9 +47,7 @@ describe('computeMergedAccess', () => {
       existingAuthorizationDetails: [],
     });
 
-    expect(merged.mergedScope).toBe(
-      'userinfo:read payment_methods.agentic aap:represent',
-    );
+    expect(merged.mergedScope).toBe('userinfo:read payment_methods.agentic');
   });
 
   it('unions source actions across requested and existing (keeps already-granted actions)', () => {

--- a/packages/cli/src/auth/scopes.ts
+++ b/packages/cli/src/auth/scopes.ts
@@ -1,6 +1,7 @@
 export const DEFAULT_SCOPES = [
   'userinfo:read',
   'payment_methods.agentic',
+  'aap:represent',
 ] as const;
 
 export const DEFAULT_SCOPE = DEFAULT_SCOPES.join(' ');

--- a/packages/cli/src/auth/scopes.ts
+++ b/packages/cli/src/auth/scopes.ts
@@ -1,7 +1,6 @@
 export const DEFAULT_SCOPES = [
   'userinfo:read',
   'payment_methods.agentic',
-  'aap:represent',
 ] as const;
 
 export const DEFAULT_SCOPE = DEFAULT_SCOPES.join(' ');

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -1,7 +1,7 @@
 import { Cli } from 'incur';
 import { type CliAuthStorage, Storage, storage } from './auth/storage';
-import { createAttestationsCli } from './commands/attestations';
 import { createAuthCli } from './commands/auth';
+import { createIdentityCli } from './commands/identity';
 import { createBalancesCli } from './commands/balances';
 import { createDemoCli } from './commands/demo';
 import { createMppCli } from './commands/mpp';
@@ -95,9 +95,10 @@ const identityCommandsEnabled =
 
 if (identityCommandsEnabled) {
   cli.command(
-    createAttestationsCli((accessToken) =>
-      factory.createAttestationsResource(accessToken),
-    ),
+    createIdentityCli({
+      createAttestationsResource: (accessToken) =>
+        factory.createAttestationsResource(accessToken),
+    }),
   );
 }
 cli.command(

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -89,7 +89,17 @@ if (!isAgent && process.stdout.isTTY) {
   }
 }
 
-cli.command(createAttestationsCli(() => factory.createAttestationsResource()));
+const identityCommandsEnabled =
+  process.env.LINK_IDENTITY_COMMANDS === '1' ||
+  process.env.LINK_IDENTITY_COMMANDS === 'true';
+
+if (identityCommandsEnabled) {
+  cli.command(
+    createAttestationsCli((accessToken) =>
+      factory.createAttestationsResource(accessToken),
+    ),
+  );
+}
 cli.command(
   createAuthCli(authRepo, getUpdateInfo, authStorage, envAccessToken),
 );

--- a/packages/cli/src/cli.tsx
+++ b/packages/cli/src/cli.tsx
@@ -1,5 +1,6 @@
 import { Cli } from 'incur';
 import { type CliAuthStorage, Storage, storage } from './auth/storage';
+import { createAttestationsCli } from './commands/attestations';
 import { createAuthCli } from './commands/auth';
 import { createBalancesCli } from './commands/balances';
 import { createDemoCli } from './commands/demo';
@@ -88,6 +89,7 @@ if (!isAgent && process.stdout.isTTY) {
   }
 }
 
+cli.command(createAttestationsCli(() => factory.createAttestationsResource()));
 cli.command(
   createAuthCli(authRepo, getUpdateInfo, authStorage, envAccessToken),
 );

--- a/packages/cli/src/commands/attestations/index.tsx
+++ b/packages/cli/src/commands/attestations/index.tsx
@@ -6,12 +6,13 @@ export function createAttestationsCli(
   createResource: (accessToken?: string) => IAttestationsResource,
 ) {
   const cli = Cli.create('attestations', {
-    description: 'Agent Attestation Token (AAT) commands',
+    description:
+      'A privacy-preserving token that shows Link attests to your agent.',
   });
 
   cli.command('request', {
     description:
-      'Request attestation tokens from an IDP using the Privacy Pass Blind RSA protocol (RFC 9578 type 0x0002). Returns tokens ready for use in Authorization: PrivateToken headers.',
+      'Get privacy-preserving tokens that show Link attests to your agent.',
     options: requestOptions,
     mcp: false,
     outputPolicy: 'agent-only' as const,

--- a/packages/cli/src/commands/attestations/index.tsx
+++ b/packages/cli/src/commands/attestations/index.tsx
@@ -13,6 +13,7 @@ export function createAttestationsCli(
     description:
       'Request attestation tokens from an IDP using the Privacy Pass Blind RSA protocol (RFC 9578 type 0x0002). Returns tokens ready for use in Authorization: PrivateToken headers.',
     options: requestOptions,
+    mcp: false,
     outputPolicy: 'agent-only' as const,
     async run(c) {
       const { count, issuer, accessToken } = c.options;

--- a/packages/cli/src/commands/attestations/index.tsx
+++ b/packages/cli/src/commands/attestations/index.tsx
@@ -1,0 +1,29 @@
+import type { IAttestationsResource } from '@stripe/link-sdk';
+import { Cli } from 'incur';
+import { requestOptions } from './schema';
+
+export function createAttestationsCli(
+  createResource: (accessToken?: string) => IAttestationsResource,
+) {
+  const cli = Cli.create('attestations', {
+    description: 'Agent Attestation Token (AAT) commands',
+  });
+
+  cli.command('request', {
+    description:
+      'Request attestation tokens from an IDP using the Privacy Pass Blind RSA protocol (RFC 9578 type 0x0002). Returns tokens ready for use in Authorization: PrivateToken headers.',
+    options: requestOptions,
+    outputPolicy: 'agent-only' as const,
+    async run(c) {
+      const { count, issuer, accessToken } = c.options;
+      const token = accessToken ?? process.env.AAP_ACCESS_TOKEN;
+
+      return createResource(token).request({
+        issuer,
+        count,
+      });
+    },
+  });
+
+  return cli;
+}

--- a/packages/cli/src/commands/attestations/index.tsx
+++ b/packages/cli/src/commands/attestations/index.tsx
@@ -16,9 +16,8 @@ export function createAttestationsCli(
     outputPolicy: 'agent-only' as const,
     async run(c) {
       const { count, issuer, accessToken } = c.options;
-      const token = accessToken ?? process.env.AAP_ACCESS_TOKEN;
 
-      return createResource(token).request({
+      return createResource(accessToken).request({
         issuer,
         count,
       });

--- a/packages/cli/src/commands/attestations/schema.ts
+++ b/packages/cli/src/commands/attestations/schema.ts
@@ -15,6 +15,6 @@ export const requestOptions = z.object({
     .string()
     .optional()
     .describe(
-      'Bearer token for IDP authentication. Defaults to the AAP_ACCESS_TOKEN env var, then the stored credentials from "link-cli auth login".',
+      'Bearer token for IDP authentication. Defaults to the stored credentials from "link-cli auth login".',
     ),
 });

--- a/packages/cli/src/commands/attestations/schema.ts
+++ b/packages/cli/src/commands/attestations/schema.ts
@@ -1,0 +1,20 @@
+import { z } from 'incur';
+
+export const requestOptions = z.object({
+  count: z.coerce
+    .number()
+    .int()
+    .positive()
+    .max(100)
+    .describe('Number of attestation tokens to request'),
+  issuer: z
+    .string()
+    .default('https://api.link.com')
+    .describe('Issuer origin URL'),
+  accessToken: z
+    .string()
+    .optional()
+    .describe(
+      'Bearer token for IDP authentication (needs the aap:represent scope). Defaults to the AAP_ACCESS_TOKEN env var, then the stored credentials from "link-cli auth login".',
+    ),
+});

--- a/packages/cli/src/commands/attestations/schema.ts
+++ b/packages/cli/src/commands/attestations/schema.ts
@@ -6,15 +6,15 @@ export const requestOptions = z.object({
     .int()
     .positive()
     .max(100)
-    .describe('Number of attestation tokens to request'),
+    .describe('Number of tokens to request'),
   issuer: z
     .string()
     .default('https://api.link.com')
-    .describe('Issuer origin URL'),
+    .describe('Link origin that attests to your agent'),
   accessToken: z
     .string()
     .optional()
     .describe(
-      'Bearer token for IDP authentication. Defaults to the stored credentials from "link-cli auth login".',
+      'Access token. Defaults to the stored credentials from "link-cli auth login".',
     ),
 });

--- a/packages/cli/src/commands/attestations/schema.ts
+++ b/packages/cli/src/commands/attestations/schema.ts
@@ -15,6 +15,6 @@ export const requestOptions = z.object({
     .string()
     .optional()
     .describe(
-      'Bearer token for IDP authentication (needs the aap:represent scope). Defaults to the AAP_ACCESS_TOKEN env var, then the stored credentials from "link-cli auth login".',
+      'Bearer token for IDP authentication. Defaults to the AAP_ACCESS_TOKEN env var, then the stored credentials from "link-cli auth login".',
     ),
 });

--- a/packages/cli/src/commands/identity/index.tsx
+++ b/packages/cli/src/commands/identity/index.tsx
@@ -1,0 +1,17 @@
+import type { IAttestationsResource } from '@stripe/link-sdk';
+import { Cli } from 'incur';
+import { createAttestationsCli } from '../attestations';
+
+export function createIdentityCli(options: {
+  createAttestationsResource: (
+    accessToken?: string,
+  ) => IAttestationsResource;
+}) {
+  const cli = Cli.create('identity', {
+    description:
+      'Privacy-preserving tokens that show Link attests to your agent.',
+  });
+
+  cli.command(createAttestationsCli(options.createAttestationsResource));
+  return cli;
+}

--- a/packages/cli/src/utils/__tests__/resource-factory.test.ts
+++ b/packages/cli/src/utils/__tests__/resource-factory.test.ts
@@ -25,6 +25,9 @@ describe('ResourceFactory', () => {
     const factory = new ResourceFactory();
 
     expect(factory.createAuthResource()).toBe(factory.createAuthResource());
+    expect(factory.createAttestationsResource()).toBe(
+      factory.createAttestationsResource(),
+    );
     expect(factory.createSpendRequestResource()).toBe(
       factory.createSpendRequestResource(),
     );
@@ -38,6 +41,7 @@ describe('ResourceFactory', () => {
       factory.createWebBotAuthResource(),
     );
     expect(factory.createAuthResource()).toBeInstanceOf(LinkAuthResource);
+    expect(factory.createAttestationsResource().request).toBeTypeOf('function');
     expect(factory.createSpendRequestResource().create).toBeTypeOf('function');
     expect(factory.createPaymentMethodsResource().list).toBeTypeOf('function');
     expect(factory.createBalancesResource().list).toBeTypeOf('function');

--- a/packages/cli/src/utils/resource-factory.ts
+++ b/packages/cli/src/utils/resource-factory.ts
@@ -1,5 +1,6 @@
 import {
   type AccessTokenProvider,
+  type IAttestationsResource,
   type IBalancesResource,
   type IPaymentMethodsResource,
   type IReportResource,
@@ -70,6 +71,10 @@ interface ResourceFactoryOptions {
   fetch?: typeof globalThis.fetch;
 }
 
+type SdkAuthentication =
+  | { accessToken: string; getAccessToken?: never }
+  | { accessToken?: never; getAccessToken: AccessTokenProvider };
+
 function createProxyFetch(
   baseFetch: typeof globalThis.fetch,
   proxyUrl: string,
@@ -108,6 +113,7 @@ export class ResourceFactory {
   private _authResource?: IAuthResource;
   private accessTokenProvider?: ReturnType<typeof createAccessTokenProvider>;
   private sdkClient?: Link;
+  private attestationsResource?: IAttestationsResource;
   private spendRequestResource?: ISpendRequestResource;
   private paymentMethodsResource?: IPaymentMethodsResource;
   private shippingAddressResource?: IShippingAddressResource;
@@ -134,11 +140,11 @@ export class ResourceFactory {
     this._authResource = options.authResource;
   }
 
-  private createSdkOptions(getAccessToken: AccessTokenProvider): LinkOptions {
+  private createSdkOptions(authentication: SdkAuthentication): LinkOptions {
     return {
       verbose: this.verbose,
       defaultHeaders: this.defaultHeaders,
-      getAccessToken,
+      ...authentication,
       apiBaseUrl: this.apiBaseUrl,
       spendRequestBaseUrl: this.spendRequestBaseUrl,
       fetch: this.fetch,
@@ -214,10 +220,28 @@ export class ResourceFactory {
   private createSdkClient(): Link {
     if (!this.sdkClient) {
       this.sdkClient = new Link(
-        this.createSdkOptions(this.createSdkAccessTokenProvider()),
+        this.createSdkOptions({
+          getAccessToken: this.createSdkAccessTokenProvider(),
+        }),
       );
     }
     return this.sdkClient;
+  }
+
+  createAttestationsResource(accessToken?: string): IAttestationsResource {
+    if (accessToken !== undefined) {
+      return sanitizeResource(
+        new Link(this.createSdkOptions({ accessToken })).attestations,
+      );
+    }
+    if (this.attestationsResource) {
+      return this.attestationsResource;
+    }
+
+    this.attestationsResource = sanitizeResource(
+      this.createSdkClient().attestations,
+    );
+    return this.attestationsResource;
   }
 
   createSpendRequestResource(): ISpendRequestResource {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,6 +1,8 @@
 import type { LinkOptions } from '@/config';
+import { AttestationsResource } from '@/resources/attestations';
 import { BalancesResource } from '@/resources/balances';
 import type {
+  IAttestationsResource,
   IBalancesResource,
   IPaymentMethodsResource,
   IReportResource,
@@ -21,6 +23,7 @@ import { UserInfoResource } from '@/resources/user-info';
 import { WebBotAuthResource } from '@/resources/web-bot-auth';
 
 export class Link {
+  readonly attestations: IAttestationsResource;
   readonly spendRequests: ISpendRequestResource;
   readonly paymentMethods: IPaymentMethodsResource;
   readonly shippingAddresses: IShippingAddressResource;
@@ -32,6 +35,7 @@ export class Link {
   readonly reports: IReportResource;
 
   constructor(options: LinkOptions) {
+    this.attestations = new AttestationsResource(options);
     this.spendRequests = new SpendRequestResource(options);
     this.paymentMethods = new PaymentMethodsResource(options);
     this.shippingAddresses = new ShippingAddressResource(options);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,4 +9,5 @@ export {
 } from './errors';
 export * from './types/index';
 export * from './resources/interfaces';
+export * from './resources/attestations';
 export { getDuplicateSpendRequest } from './resources/spend-request';

--- a/packages/sdk/src/resources/__tests__/attestations-crypto.test.ts
+++ b/packages/sdk/src/resources/__tests__/attestations-crypto.test.ts
@@ -1,0 +1,92 @@
+import { generateKeyPairSync, randomBytes } from 'node:crypto';
+import {
+  generateBlindedMessages,
+  unblindSignatures,
+} from '@/resources/attestations-crypto';
+import { describe, expect, it } from 'vitest';
+
+function bytesToBigInt(bytes: Uint8Array): bigint {
+  return BigInt(`0x${Buffer.from(bytes).toString('hex')}`);
+}
+
+function bigIntToBytes(value: bigint, length: number): Uint8Array {
+  return new Uint8Array(
+    Buffer.from(value.toString(16).padStart(length * 2, '0'), 'hex'),
+  );
+}
+
+function modPow(base: bigint, exponent: bigint, modulus: bigint): bigint {
+  let result = 1n;
+  let current = base % modulus;
+  let remaining = exponent;
+  while (remaining > 0n) {
+    if (remaining & 1n) {
+      result = (result * current) % modulus;
+    }
+    remaining >>= 1n;
+    current = (current * current) % modulus;
+  }
+  return result;
+}
+
+function decodeJwkInteger(value: string): bigint {
+  return bytesToBigInt(new Uint8Array(Buffer.from(value, 'base64url')));
+}
+
+describe('Blind RSA finalization', () => {
+  const { publicKey, privateKey } = generateKeyPairSync('rsa', {
+    modulusLength: 1024,
+    publicExponent: 0x10001,
+  });
+  const spki = new Uint8Array(
+    publicKey.export({ format: 'der', type: 'spki' }),
+  );
+  const privateJwk = privateKey.export({ format: 'jwk' });
+  const modulus = decodeJwkInteger(privateJwk.n as string);
+  const privateExponent = decodeJwkInteger(privateJwk.d as string);
+
+  it('accepts a correctly signed blinded message', () => {
+    const state = generateBlindedMessages(
+      spki,
+      1,
+      new Uint8Array(randomBytes(32)),
+    );
+    const token = state.tokens[0];
+    expect(token).toBeDefined();
+    if (!token) {
+      throw new Error('Expected one blinded token');
+    }
+    const blindedMessage = bytesToBigInt(token.blindedMsg);
+    const blindSignature = bigIntToBytes(
+      modPow(blindedMessage, privateExponent, modulus),
+      token.blindedMsg.length,
+    );
+
+    const tokens = unblindSignatures(state, [
+      Buffer.from(blindSignature).toString('base64url'),
+    ]);
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]?.raw).toHaveLength(2 + 32 + 32 + 32 + 128);
+  });
+
+  it('rejects an invalid blind signature after unblinding', () => {
+    const state = generateBlindedMessages(
+      spki,
+      1,
+      new Uint8Array(randomBytes(32)),
+    );
+    const token = state.tokens[0];
+    expect(token).toBeDefined();
+    if (!token) {
+      throw new Error('Expected one blinded token');
+    }
+    const invalidSignature = Buffer.alloc(token.blindedMsg.length).toString(
+      'base64url',
+    );
+
+    expect(() => unblindSignatures(state, [invalidSignature])).toThrow(
+      'Blind signature 0 failed verification',
+    );
+  });
+});

--- a/packages/sdk/src/resources/__tests__/attestations.test.ts
+++ b/packages/sdk/src/resources/__tests__/attestations.test.ts
@@ -121,13 +121,60 @@ describe('AttestationsResource', () => {
     expect(getAccessToken).toHaveBeenNthCalledWith(2, { forceRefresh: true });
     expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({
       headers: expect.objectContaining({
+        Accept: 'application/private-token-generic-batch-response',
         Authorization: 'Bearer initial-token',
+        'Content-Type': 'application/private-token-generic-batch-request',
       }),
     });
+    const issuanceBody = fetchMock.mock.calls[2]?.[1]?.body;
+    expect(issuanceBody).toBeInstanceOf(ArrayBuffer);
+    const encodedRequest = Buffer.from(issuanceBody as ArrayBuffer);
+    expect(encodedRequest.subarray(0, 2)).toEqual(Buffer.from([0x40, 0x83]));
+    expect(encodedRequest.subarray(2, 4)).toEqual(Buffer.from([0x00, 0x02]));
+    expect(encodedRequest).toHaveLength(2 + 3 + 128);
     expect(fetchMock.mock.calls[3]?.[1]).toMatchObject({
       headers: expect.objectContaining({
         Authorization: 'Bearer refreshed-token',
       }),
     });
+  });
+
+  it('decodes GenericBatchTokenResponse optional entries', async () => {
+    const { publicKey } = generateKeyPairSync('rsa', {
+      modulusLength: 1024,
+      publicExponent: 0x10001,
+    });
+    const tokenKey = publicKey
+      .export({ format: 'der', type: 'spki' })
+      .toString('base64');
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.endsWith('/.well-known/aap-issuer')) {
+        return jsonResponse({
+          issuer: 'https://issuer.example',
+          token_issuance_endpoint: 'https://issuer.example/issue',
+          token_keys: 'https://issuer.example/token-keys',
+        });
+      }
+      if (url.endsWith('/token-keys')) {
+        return jsonResponse({
+          'token-keys': [{ 'token-type': 0x0002, 'token-key': tokenKey }],
+        });
+      }
+      return new Response(Buffer.from([0x01, 0x00]), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/private-token-generic-batch-response',
+        },
+      });
+    });
+    const resource = new AttestationsResource({
+      accessToken: 'secret',
+      fetch: fetchMock,
+    });
+
+    await expect(
+      resource.request({ issuer: 'https://issuer.example', count: 1 }),
+    ).rejects.toThrow('Issuer refused token request at index 0');
   });
 });

--- a/packages/sdk/src/resources/__tests__/attestations.test.ts
+++ b/packages/sdk/src/resources/__tests__/attestations.test.ts
@@ -1,0 +1,133 @@
+import { generateKeyPairSync } from 'node:crypto';
+import { LinkResponseError } from '@/errors';
+import { AttestationsResource } from '@/resources/attestations';
+import { describe, expect, it, vi } from 'vitest';
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('AttestationsResource', () => {
+  it('rejects non-HTTPS and IP-literal issuers before fetching', async () => {
+    const fetchMock = vi.fn();
+    const resource = new AttestationsResource({
+      accessToken: 'secret',
+      fetch: fetchMock,
+    });
+
+    await expect(
+      resource.request({ issuer: 'http://127.0.0.1', count: 1 }),
+    ).rejects.toThrow('Issuer must be an HTTPS origin with a DNS hostname');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects off-origin metadata before sending the access token', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        jsonResponse({
+          issuer: 'https://issuer.example',
+          token_issuance_endpoint: 'https://attacker.example/issue',
+          token_keys: 'https://issuer.example/token-keys',
+        }),
+    );
+    const resource = new AttestationsResource({
+      accessToken: 'secret',
+      fetch: fetchMock,
+    });
+
+    await expect(
+      resource.request({ issuer: 'https://issuer.example', count: 1 }),
+    ).rejects.toThrow('token_issuance_endpoint must be an HTTPS URL');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual({ redirect: 'manual' });
+  });
+
+  it('refuses discovery redirects', async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response('', {
+          status: 302,
+          headers: { Location: 'https://attacker.example/metadata' },
+        }),
+    );
+    const resource = new AttestationsResource({
+      accessToken: 'secret',
+      fetch: fetchMock,
+    });
+
+    await expect(
+      resource.request({ issuer: 'https://issuer.example', count: 1 }),
+    ).rejects.toThrow('Refused redirect');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps malformed issuer metadata in LinkResponseError', async () => {
+    const resource = new AttestationsResource({
+      accessToken: 'secret',
+      fetch: vi.fn(async () => jsonResponse({ issuer: 42 })),
+    });
+
+    await expect(
+      resource.request({ issuer: 'https://issuer.example', count: 1 }),
+    ).rejects.toBeInstanceOf(LinkResponseError);
+  });
+
+  it('refreshes LinkOptions authentication after an issuance 401', async () => {
+    const { publicKey } = generateKeyPairSync('rsa', {
+      modulusLength: 1024,
+      publicExponent: 0x10001,
+    });
+    const tokenKey = publicKey
+      .export({ format: 'der', type: 'spki' })
+      .toString('base64');
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        if (url.endsWith('/.well-known/aap-issuer')) {
+          return jsonResponse({
+            issuer: 'https://issuer.example',
+            token_issuance_endpoint: 'https://issuer.example/issue',
+            token_keys: 'https://issuer.example/token-keys',
+          });
+        }
+        if (url.endsWith('/token-keys')) {
+          return jsonResponse({
+            'token-keys': [{ 'token-type': 0x0002, 'token-key': tokenKey }],
+          });
+        }
+        return jsonResponse(
+          { error: `unauthorized: ${String(init?.headers)}` },
+          401,
+        );
+      },
+    );
+    const getAccessToken = vi.fn(
+      ({ forceRefresh }: { forceRefresh?: boolean } = {}) =>
+        forceRefresh ? 'refreshed-token' : 'initial-token',
+    );
+    const resource = new AttestationsResource({
+      getAccessToken,
+      fetch: fetchMock,
+    });
+
+    await expect(
+      resource.request({ issuer: 'https://issuer.example', count: 1 }),
+    ).rejects.toThrow('Failed to issue attestation tokens (401)');
+
+    expect(getAccessToken).toHaveBeenNthCalledWith(1, undefined);
+    expect(getAccessToken).toHaveBeenNthCalledWith(2, { forceRefresh: true });
+    expect(fetchMock.mock.calls[2]?.[1]).toMatchObject({
+      headers: expect.objectContaining({
+        Authorization: 'Bearer initial-token',
+      }),
+    });
+    expect(fetchMock.mock.calls[3]?.[1]).toMatchObject({
+      headers: expect.objectContaining({
+        Authorization: 'Bearer refreshed-token',
+      }),
+    });
+  });
+});

--- a/packages/sdk/src/resources/__tests__/factory.test.ts
+++ b/packages/sdk/src/resources/__tests__/factory.test.ts
@@ -1,4 +1,5 @@
 import Link from '@/client';
+import { AttestationsResource } from '@/resources/attestations';
 import { PaymentMethodsResource } from '@/resources/payment-methods';
 import { ReportResource } from '@/resources/report';
 import { SpendRequestResource } from '@/resources/spend-request';
@@ -14,6 +15,7 @@ describe('Link', () => {
       apiBaseUrl: 'https://api.example.com',
     });
 
+    expect(client.attestations).toBeInstanceOf(AttestationsResource);
     expect(client.spendRequests).toBeInstanceOf(SpendRequestResource);
     expect(client.paymentMethods).toBeInstanceOf(PaymentMethodsResource);
     expect(client.transactions).toBeInstanceOf(TransactionsResource);
@@ -22,6 +24,7 @@ describe('Link', () => {
     expect(client.spendRequests.create).toBeTypeOf('function');
     expect(client.spendRequests.update).toBeTypeOf('function');
     expect(client.spendRequests.retrieve).toBeTypeOf('function');
+    expect(client.attestations.request).toBeTypeOf('function');
     expect(client.paymentMethods.list).toBeTypeOf('function');
     expect(client.transactions.list).toBeTypeOf('function');
   });

--- a/packages/sdk/src/resources/attestations-crypto.ts
+++ b/packages/sdk/src/resources/attestations-crypto.ts
@@ -1,0 +1,395 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+
+const TOKEN_TYPE = 0x0002;
+const NONCE_SIZE = 32;
+const CHALLENGE_DIGEST_SIZE = 32;
+const TOKEN_KEY_ID_SIZE = 32;
+
+interface RsaPublicKey {
+  n: bigint;
+  e: bigint;
+  nLen: number;
+}
+
+interface BlindedToken {
+  nonce: Uint8Array;
+  blindedMsg: Uint8Array;
+  blindInverse: bigint;
+  encodedMessage: Uint8Array;
+}
+
+export interface BlindingState {
+  tokens: BlindedToken[];
+  publicKey: RsaPublicKey;
+  challengeDigest: Uint8Array;
+  tokenKeyId: Uint8Array;
+}
+
+export interface FinalToken {
+  raw: Uint8Array;
+  base64url: string;
+}
+
+export function base64urlEncode(buf: Uint8Array): string {
+  return Buffer.from(buf).toString('base64url');
+}
+
+function base64urlDecode(str: string): Uint8Array {
+  return new Uint8Array(Buffer.from(str, 'base64url'));
+}
+
+function bytesToBigInt(bytes: Uint8Array): bigint {
+  let hex = '';
+  for (const b of bytes) {
+    hex += b.toString(16).padStart(2, '0');
+  }
+  return hex.length === 0 ? 0n : BigInt(`0x${hex}`);
+}
+
+function bigIntToBytes(n: bigint, length: number): Uint8Array {
+  const hex = n.toString(16).padStart(length * 2, '0');
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function modPow(base: bigint, exp: bigint, mod: bigint): bigint {
+  let result = 1n;
+  let b = ((base % mod) + mod) % mod;
+  let e = exp;
+  while (e > 0n) {
+    if (e & 1n) {
+      result = (result * b) % mod;
+    }
+    e >>= 1n;
+    b = (b * b) % mod;
+  }
+  return result;
+}
+
+function modInverse(a: bigint, m: bigint): bigint {
+  let [oldR, r] = [a, m];
+  let [oldS, s] = [1n, 0n];
+  while (r !== 0n) {
+    const q = oldR / r;
+    [oldR, r] = [r, oldR - q * r];
+    [oldS, s] = [s, oldS - q * s];
+  }
+  return ((oldS % m) + m) % m;
+}
+
+function parseSpkiPublicKey(spkiDer: Uint8Array): RsaPublicKey {
+  // SubjectPublicKeyInfo ::= SEQUENCE { algorithm AlgorithmIdentifier, subjectPublicKey BIT STRING }
+  // RSAPublicKey ::= SEQUENCE { modulus INTEGER, publicExponent INTEGER }
+  //
+  // The DER must be walked structurally, not scanned for tag bytes: an
+  // id-RSASSA-PSS AlgorithmIdentifier carries nested hash/MGF1/saltLength
+  // parameters whose bytes include values that look like BIT STRING and
+  // INTEGER tags.
+  const spki = readSequence(spkiDer, 0);
+
+  // Skip the AlgorithmIdentifier, then read the BIT STRING that follows it.
+  const algorithm = readTlv(spkiDer, spki.contentStart);
+  const bitString = readTlv(spkiDer, algorithm.end);
+  if (bitString.tag !== 0x03) {
+    throw new Error(
+      `Expected BIT STRING in SPKI, got 0x${bitString.tag.toString(16)}`,
+    );
+  }
+
+  // First content byte of a BIT STRING is the unused-bits count (0 here).
+  const rsaPublicKeyDer = spkiDer.slice(
+    bitString.contentStart + 1,
+    bitString.end,
+  );
+
+  const rsaPublicKey = readSequence(rsaPublicKeyDer, 0);
+  const modulus = readInteger(rsaPublicKeyDer, rsaPublicKey.contentStart);
+  const exponent = readInteger(rsaPublicKeyDer, modulus.end);
+
+  return {
+    n: bytesToBigInt(modulus.value),
+    e: bytesToBigInt(exponent.value),
+    nLen: modulus.value.length,
+  };
+}
+
+interface Tlv {
+  tag: number;
+  contentStart: number;
+  end: number;
+}
+
+function readTlv(data: Uint8Array, offset: number): Tlv {
+  if (offset >= data.length) {
+    throw new Error(`Unexpected end of DER at offset ${offset}`);
+  }
+  const tag = data[offset];
+  if (tag === undefined) {
+    throw new Error(`Unexpected end of DER at offset ${offset}`);
+  }
+  const { value: length, bytesRead } = parseDerLength(data, offset + 1);
+  const contentStart = offset + 1 + bytesRead;
+  const end = contentStart + length;
+  if (end > data.length) {
+    throw new Error(`DER element at offset ${offset} overruns the buffer`);
+  }
+  return { tag, contentStart, end };
+}
+
+function readSequence(data: Uint8Array, offset: number): Tlv {
+  const tlv = readTlv(data, offset);
+  if (tlv.tag !== 0x30) {
+    throw new Error(
+      `Expected SEQUENCE at offset ${offset}, got 0x${tlv.tag.toString(16)}`,
+    );
+  }
+  return tlv;
+}
+
+function readInteger(
+  data: Uint8Array,
+  offset: number,
+): { value: Uint8Array; end: number } {
+  const tlv = readTlv(data, offset);
+  if (tlv.tag !== 0x02) {
+    throw new Error(
+      `Expected INTEGER at offset ${offset}, got 0x${tlv.tag.toString(16)}`,
+    );
+  }
+  let value = data.slice(tlv.contentStart, tlv.end);
+  // Strip the DER sign byte.
+  if (value.length > 1 && value[0] === 0x00) {
+    value = value.slice(1);
+  }
+  return { value, end: tlv.end };
+}
+
+function parseDerLength(
+  data: Uint8Array,
+  offset: number,
+): { value: number; bytesRead: number } {
+  const first = data[offset];
+  if (first === undefined) {
+    throw new Error(`Unexpected end of DER at offset ${offset}`);
+  }
+  if (first < 0x80) {
+    return { value: first, bytesRead: 1 };
+  }
+  const numBytes = first & 0x7f;
+  if (numBytes === 0 || offset + numBytes >= data.length) {
+    throw new Error(`Invalid DER length at offset ${offset}`);
+  }
+  let value = 0;
+  for (let i = 0; i < numBytes; i++) {
+    const byte = data[offset + 1 + i];
+    if (byte === undefined) {
+      throw new Error(`Unexpected end of DER at offset ${offset + 1 + i}`);
+    }
+    value = value * 256 + byte;
+  }
+  return { value, bytesRead: 1 + numBytes };
+}
+
+// EMSA-PSS encoding for RSA-PSS (RFC 8017 §9.1.1) with SHA-384
+function emsaPssEncode(message: Uint8Array, emBits: number): Uint8Array {
+  const hashAlg = 'sha384';
+  const hLen = 48; // SHA-384 output
+  const sLen = 48; // salt length = hash length for RSABSSA-SHA384-PSS
+  const emLen = Math.ceil(emBits / 8);
+
+  const mHash = createHash(hashAlg).update(message).digest();
+  if (emLen < hLen + sLen + 2) {
+    throw new Error('Encoding error: emLen too small');
+  }
+
+  const salt = randomBytes(sLen);
+  // M' = (0x)00 00 00 00 00 00 00 00 || mHash || salt
+  const mPrime = Buffer.concat([Buffer.alloc(8), mHash, salt]);
+  const h = createHash(hashAlg).update(mPrime).digest();
+
+  const ps = Buffer.alloc(emLen - sLen - hLen - 2);
+  const db = Buffer.concat([ps, Buffer.from([0x01]), salt]);
+
+  const dbMask = mgf1(h, db.length, hashAlg);
+  const maskedDb = Buffer.alloc(db.length);
+  for (let i = 0; i < db.length; i++) {
+    maskedDb.writeUInt8(db.readUInt8(i) ^ dbMask.readUInt8(i), i);
+  }
+
+  // Set the leftmost bits to zero.
+  const topBits = 8 * emLen - emBits;
+  maskedDb.writeUInt8(maskedDb.readUInt8(0) & (0xff >> topBits), 0);
+
+  return new Uint8Array(Buffer.concat([maskedDb, h, Buffer.from([0xbc])]));
+}
+
+function mgf1(seed: Buffer, length: number, hashAlg: string): Buffer {
+  const hLen = hashAlg === 'sha384' ? 48 : 32;
+  const result = Buffer.alloc(length);
+  let offset = 0;
+  let counter = 0;
+
+  while (offset < length) {
+    const c = Buffer.alloc(4);
+    c.writeUInt32BE(counter);
+    const hash = createHash(hashAlg).update(seed).update(c).digest();
+    const toCopy = Math.min(hLen, length - offset);
+    hash.copy(result, offset, 0, toCopy);
+    offset += toCopy;
+    counter++;
+  }
+
+  return result;
+}
+
+function generateBlindingFactor(
+  n: bigint,
+  nLen: number,
+): { r: bigint; rInv: bigint } {
+  while (true) {
+    const rBytes = randomBytes(nLen);
+    rBytes[0] = 0;
+    const r = bytesToBigInt(new Uint8Array(rBytes));
+    if (r <= 1n || r >= n) continue;
+    const rInv = modInverse(r, n);
+    if ((r * rInv) % n === 1n) {
+      return { r, rInv };
+    }
+  }
+}
+
+export function generateBlindedMessages(
+  spkiDer: Uint8Array,
+  count: number,
+  challengeDigest: Uint8Array,
+): BlindingState {
+  const publicKey = parseSpkiPublicKey(spkiDer);
+  const tokenKeyId = new Uint8Array(
+    createHash('sha256').update(spkiDer).digest(),
+  );
+
+  const emBits = publicKey.nLen * 8 - 1;
+  const tokens: BlindedToken[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const nonce = new Uint8Array(randomBytes(NONCE_SIZE));
+    const tokenInput = new Uint8Array(
+      2 + NONCE_SIZE + CHALLENGE_DIGEST_SIZE + TOKEN_KEY_ID_SIZE,
+    );
+    tokenInput[0] = (TOKEN_TYPE >> 8) & 0xff;
+    tokenInput[1] = TOKEN_TYPE & 0xff;
+    tokenInput.set(nonce, 2);
+    tokenInput.set(challengeDigest, 2 + NONCE_SIZE);
+    tokenInput.set(tokenKeyId, 2 + NONCE_SIZE + CHALLENGE_DIGEST_SIZE);
+
+    const encoded = emsaPssEncode(tokenInput, emBits);
+    const message = bytesToBigInt(encoded);
+    const { r, rInv } = generateBlindingFactor(publicKey.n, publicKey.nLen);
+    const blindedMessage =
+      (message * modPow(r, publicKey.e, publicKey.n)) % publicKey.n;
+
+    tokens.push({
+      nonce,
+      blindedMsg: bigIntToBytes(blindedMessage, publicKey.nLen),
+      blindInverse: rInv,
+      encodedMessage: encoded,
+    });
+  }
+
+  return { tokens, publicKey, challengeDigest, tokenKeyId };
+}
+
+export function unblindSignatures(
+  state: BlindingState,
+  blindSigs: string[],
+): FinalToken[] {
+  const { tokens, publicKey, tokenKeyId } = state;
+
+  if (blindSigs.length !== tokens.length) {
+    throw new Error(
+      `Expected ${tokens.length} blind signatures, got ${blindSigs.length}`,
+    );
+  }
+
+  const results: FinalToken[] = [];
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const blindSignature = blindSigs[i];
+    if (!token || blindSignature === undefined) {
+      throw new Error(`Missing blind signature state at index ${i}`);
+    }
+    const blindSigBytes = base64urlDecode(blindSignature);
+    const blindSigInt = bytesToBigInt(blindSigBytes);
+    const sigInt = (blindSigInt * token.blindInverse) % publicKey.n;
+    const authenticator = bigIntToBytes(sigInt, publicKey.nLen);
+    const recoveredMessage = bigIntToBytes(
+      modPow(sigInt, publicKey.e, publicKey.n),
+      publicKey.nLen,
+    );
+    if (
+      !timingSafeEqual(
+        Buffer.from(recoveredMessage),
+        Buffer.from(token.encodedMessage),
+      )
+    ) {
+      throw new Error(`Blind signature ${i} failed verification`);
+    }
+
+    const raw = new Uint8Array(
+      2 +
+        NONCE_SIZE +
+        CHALLENGE_DIGEST_SIZE +
+        TOKEN_KEY_ID_SIZE +
+        publicKey.nLen,
+    );
+    raw[0] = (TOKEN_TYPE >> 8) & 0xff;
+    raw[1] = TOKEN_TYPE & 0xff;
+    raw.set(token.nonce, 2);
+    raw.set(state.challengeDigest, 2 + NONCE_SIZE);
+    raw.set(tokenKeyId, 2 + NONCE_SIZE + CHALLENGE_DIGEST_SIZE);
+    raw.set(
+      authenticator,
+      2 + NONCE_SIZE + CHALLENGE_DIGEST_SIZE + TOKEN_KEY_ID_SIZE,
+    );
+
+    results.push({
+      raw,
+      base64url: base64urlEncode(raw),
+    });
+  }
+
+  return results;
+}
+
+export function computeChallengeDigest(
+  tokenType: number,
+  issuerName: string,
+): Uint8Array {
+  const issuerBytes = Buffer.from(issuerName, 'utf-8');
+  const originBytes = Buffer.alloc(0);
+
+  const challenge = Buffer.alloc(
+    2 + 2 + issuerBytes.length + 1 + 2 + originBytes.length,
+  );
+  let offset = 0;
+
+  challenge.writeUInt16BE(tokenType, offset);
+  offset += 2;
+  challenge.writeUInt16BE(issuerBytes.length, offset);
+  offset += 2;
+  issuerBytes.copy(challenge, offset);
+  offset += issuerBytes.length;
+  challenge.writeUInt8(0, offset);
+  offset += 1;
+  challenge.writeUInt16BE(originBytes.length, offset);
+  offset += 2;
+  if (originBytes.length > 0) {
+    originBytes.copy(challenge, offset);
+  }
+
+  return new Uint8Array(createHash('sha256').update(challenge).digest());
+}

--- a/packages/sdk/src/resources/attestations.ts
+++ b/packages/sdk/src/resources/attestations.ts
@@ -1,0 +1,379 @@
+import { createHash } from 'node:crypto';
+import { isIP } from 'node:net';
+import type { LinkOptions } from '@/config';
+import {
+  LinkApiError,
+  LinkConfigurationError,
+  LinkResponseError,
+  LinkTransportError,
+} from '@/errors';
+import {
+  type FinalToken,
+  base64urlEncode,
+  computeChallengeDigest,
+  generateBlindedMessages,
+  unblindSignatures,
+} from '@/resources/attestations-crypto';
+import { BaseResource } from '@/resources/base';
+import type {
+  AttestationRequestParams,
+  AttestationRequestResult,
+  IAttestationsResource,
+} from '@/resources/interfaces';
+import { z } from 'zod';
+
+const TOKEN_TYPE_BLIND_RSA = 0x0002;
+const CONTENT_TYPE_TOKEN_REQUEST = 'application/private-token-request';
+const CONTENT_TYPE_TOKEN_RESPONSE = 'application/private-token-response';
+
+const issuerMetadataSchema = z.looseObject({
+  issuer: z.string(),
+  token_issuance_endpoint: z.string(),
+  token_keys: z.string(),
+});
+
+const tokenKeyDirectorySchema = z.looseObject({
+  'token-keys': z.array(
+    z.looseObject({
+      'token-type': z.number(),
+      'token-key': z.string(),
+    }),
+  ),
+});
+
+function base64ToBytes(value: string): Uint8Array {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  return new Uint8Array(Buffer.from(normalized, 'base64'));
+}
+
+function encodeBatchTokenRequest(
+  blindedMessages: Uint8Array[],
+  truncatedTokenKeyId: number,
+): Buffer {
+  const entries = blindedMessages.map((blindedMessage) => {
+    const entry = Buffer.alloc(3 + blindedMessage.length);
+    entry.writeUInt16BE(TOKEN_TYPE_BLIND_RSA, 0);
+    entry.writeUInt8(truncatedTokenKeyId, 2);
+    Buffer.from(blindedMessage).copy(entry, 3);
+    return entry;
+  });
+
+  const vector = Buffer.concat(entries);
+  const prefix = Buffer.alloc(2);
+  prefix.writeUInt16BE(vector.length, 0);
+  return Buffer.concat([prefix, vector]);
+}
+
+function decodeBatchTokenResponse(
+  body: Buffer,
+  elementSize: number,
+  expectedCount: number,
+): string[] {
+  if (body.length < 2) {
+    throw new Error(
+      `BatchTokenResponse too short: ${body.length} bytes (expected at least 2)`,
+    );
+  }
+
+  const vectorLength = body.readUInt16BE(0);
+  const vector = body.subarray(2);
+  if (vector.length !== vectorLength) {
+    throw new Error(
+      `BatchTokenResponse length prefix says ${vectorLength} bytes but ${vector.length} bytes follow`,
+    );
+  }
+  if (vectorLength === 0 || vectorLength % elementSize !== 0) {
+    throw new Error(
+      `BatchTokenResponse vector of ${vectorLength} bytes is not a multiple of the ${elementSize}-byte element size`,
+    );
+  }
+
+  const count = vectorLength / elementSize;
+  if (count !== expectedCount) {
+    throw new Error(
+      `Issuer returned ${count} blind signatures for ${expectedCount} token requests`,
+    );
+  }
+
+  return Array.from({ length: count }, (_, index) =>
+    base64urlEncode(
+      new Uint8Array(
+        vector.subarray(index * elementSize, (index + 1) * elementSize),
+      ),
+    ),
+  );
+}
+
+function parseIssuerOrigin(issuer: string): URL {
+  let url: URL;
+  try {
+    url = new URL(issuer);
+  } catch (error) {
+    throw new LinkConfigurationError(`Invalid issuer URL: ${issuer}`, {
+      cause: error,
+    });
+  }
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+  if (
+    url.protocol !== 'https:' ||
+    url.username ||
+    url.password ||
+    url.pathname !== '/' ||
+    url.search ||
+    url.hash ||
+    isIP(hostname) !== 0
+  ) {
+    throw new LinkConfigurationError(
+      'Issuer must be an HTTPS origin with a DNS hostname',
+    );
+  }
+  return url;
+}
+
+function requireIssuerEndpoint(
+  value: string,
+  issuerOrigin: string,
+  field: string,
+): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new TypeError(`${field} is not a valid URL`, { cause: error });
+  }
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+  if (
+    url.protocol !== 'https:' ||
+    url.origin !== issuerOrigin ||
+    url.username ||
+    url.password ||
+    isIP(hostname) !== 0
+  ) {
+    throw new TypeError(`${field} must be an HTTPS URL on the issuer origin`);
+  }
+  return url.href;
+}
+
+export class AttestationsResource
+  extends BaseResource
+  implements IAttestationsResource
+{
+  constructor(options: LinkOptions) {
+    super(options, '');
+  }
+
+  private async fetchJson(
+    url: string,
+    operation: string,
+  ): Promise<{ data: unknown; status: number }> {
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, { redirect: 'manual' });
+    } catch (error) {
+      throw new LinkTransportError(`Request failed: GET ${url}`, {
+        cause: error,
+      });
+    }
+
+    const rawBody = await response.text();
+    if (response.status >= 300 && response.status < 400) {
+      throw new LinkApiError(
+        `Refused redirect while attempting to ${operation} (${response.status})`,
+        {
+          status: response.status,
+          rawBody,
+        },
+      );
+    }
+    let data: unknown = null;
+    try {
+      data = JSON.parse(rawBody);
+    } catch (error) {
+      if (response.ok) {
+        throw new LinkResponseError(operation, response.status, {
+          cause: error,
+        });
+      }
+    }
+
+    if (!response.ok) {
+      throw new LinkApiError(
+        `Failed to ${operation} (${response.status}): ${rawBody}`,
+        {
+          status: response.status,
+          rawBody,
+          details: data,
+        },
+      );
+    }
+    return { data, status: response.status };
+  }
+
+  private async issueTokens(
+    url: string,
+    body: Uint8Array,
+    forceRefresh = false,
+  ): Promise<Response> {
+    const token = await this.getAccessToken(
+      forceRefresh ? { forceRefresh: true } : undefined,
+    );
+    const requestBody = new ArrayBuffer(body.byteLength);
+    new Uint8Array(requestBody).set(body);
+    try {
+      return await this.fetchImpl(url, {
+        method: 'POST',
+        redirect: 'manual',
+        headers: {
+          'Content-Type': CONTENT_TYPE_TOKEN_REQUEST,
+          Accept: CONTENT_TYPE_TOKEN_RESPONSE,
+          Authorization: `Bearer ${token}`,
+        },
+        body: requestBody,
+      });
+    } catch (error) {
+      throw new LinkTransportError(`Request failed: POST ${url}`, {
+        cause: error,
+      });
+    }
+  }
+
+  async request(
+    params: AttestationRequestParams,
+  ): Promise<AttestationRequestResult> {
+    const { issuer, count } = params;
+    if (!Number.isInteger(count) || count < 1 || count > 100) {
+      throw new LinkConfigurationError(
+        'Attestation token count must be an integer from 1 to 100',
+      );
+    }
+    const issuerUrl = parseIssuerOrigin(issuer);
+    const metadataUrl = new URL('/.well-known/aap-issuer', issuerUrl).href;
+    const metadataResponse = await this.fetchJson(
+      metadataUrl,
+      'fetch issuer metadata',
+    );
+    const metadata = this.parseResponse(
+      'parse issuer metadata',
+      metadataResponse.status,
+      () => issuerMetadataSchema.parse(metadataResponse.data),
+    );
+    let tokenKeysUrl: string;
+    let issuanceUrl: string;
+    try {
+      const metadataIssuerUrl = parseIssuerOrigin(metadata.issuer);
+      if (metadataIssuerUrl.origin !== issuerUrl.origin) {
+        throw new TypeError(
+          'issuer metadata identifier must match the discovery origin',
+        );
+      }
+      tokenKeysUrl = requireIssuerEndpoint(
+        metadata.token_keys,
+        issuerUrl.origin,
+        'token_keys',
+      );
+      issuanceUrl = requireIssuerEndpoint(
+        metadata.token_issuance_endpoint,
+        issuerUrl.origin,
+        'token_issuance_endpoint',
+      );
+    } catch (error) {
+      throw new LinkResponseError(
+        'validate issuer metadata',
+        metadataResponse.status,
+        { cause: error },
+      );
+    }
+    const directoryResponse = await this.fetchJson(
+      tokenKeysUrl,
+      'fetch token keys',
+    );
+    const directory = this.parseResponse(
+      'parse token key directory',
+      directoryResponse.status,
+      () => tokenKeyDirectorySchema.parse(directoryResponse.data),
+    );
+    const tokenKey = directory['token-keys'].find(
+      (entry) => entry['token-type'] === TOKEN_TYPE_BLIND_RSA,
+    );
+    if (!tokenKey) {
+      throw new LinkResponseError(
+        'select Blind RSA token key',
+        directoryResponse.status,
+        {
+          cause: new Error('No token key with type 0x0002 found in directory'),
+        },
+      );
+    }
+
+    const spkiDer = base64ToBytes(tokenKey['token-key']);
+    const challengeDigest = computeChallengeDigest(
+      TOKEN_TYPE_BLIND_RSA,
+      new URL(metadata.issuer).hostname,
+    );
+    const blindingState = generateBlindedMessages(
+      spkiDer,
+      count,
+      challengeDigest,
+    );
+    const tokenKeyIdBytes = new Uint8Array(
+      createHash('sha256').update(spkiDer).digest(),
+    );
+    const truncatedTokenKeyId = tokenKeyIdBytes.at(-1);
+    if (truncatedTokenKeyId === undefined) {
+      throw new LinkResponseError('derive Blind RSA token key ID', 200);
+    }
+    const requestBody = encodeBatchTokenRequest(
+      blindingState.tokens.map((token) => token.blindedMsg),
+      truncatedTokenKeyId,
+    );
+
+    let issueResponse = await this.issueTokens(
+      issuanceUrl,
+      new Uint8Array(requestBody),
+    );
+    if (issueResponse.status === 401 && this.canRefreshAccessToken) {
+      issueResponse = await this.issueTokens(
+        issuanceUrl,
+        new Uint8Array(requestBody),
+        true,
+      );
+    }
+
+    if (!issueResponse.ok) {
+      const rawBody = await issueResponse.text();
+      throw new LinkApiError(
+        `Failed to issue attestation tokens (${issueResponse.status}): ${rawBody}`,
+        {
+          status: issueResponse.status,
+          rawBody,
+        },
+      );
+    }
+
+    let blindSignatures: string[];
+    try {
+      blindSignatures = decodeBatchTokenResponse(
+        Buffer.from(await issueResponse.arrayBuffer()),
+        blindingState.publicKey.nLen,
+        count,
+      );
+    } catch (error) {
+      throw new LinkResponseError(
+        'decode attestation token response',
+        issueResponse.status,
+        { cause: error },
+      );
+    }
+    const finalTokens: FinalToken[] = unblindSignatures(
+      blindingState,
+      blindSignatures,
+    );
+
+    return {
+      tokens: finalTokens.map((finalToken) => finalToken.base64url),
+      issuer: metadata.issuer,
+      token_key_id: base64urlEncode(blindingState.tokenKeyId),
+      count: finalTokens.length,
+    };
+  }
+}

--- a/packages/sdk/src/resources/attestations.ts
+++ b/packages/sdk/src/resources/attestations.ts
@@ -23,8 +23,10 @@ import type {
 import { z } from 'zod';
 
 const TOKEN_TYPE_BLIND_RSA = 0x0002;
-const CONTENT_TYPE_TOKEN_REQUEST = 'application/private-token-request';
-const CONTENT_TYPE_TOKEN_RESPONSE = 'application/private-token-response';
+const CONTENT_TYPE_TOKEN_REQUEST =
+  'application/private-token-generic-batch-request';
+const CONTENT_TYPE_TOKEN_RESPONSE =
+  'application/private-token-generic-batch-response';
 
 const issuerMetadataSchema = z.looseObject({
   issuer: z.string(),
@@ -46,6 +48,51 @@ function base64ToBytes(value: string): Uint8Array {
   return new Uint8Array(Buffer.from(normalized, 'base64'));
 }
 
+function minQuicVarintLength(value: number): 1 | 2 | 4 | 8 {
+  if (value < 2 ** 6) return 1;
+  if (value < 2 ** 14) return 2;
+  if (value < 2 ** 30) return 4;
+  return 8;
+}
+
+function encodeQuicVarint(value: number): Buffer {
+  if (!Number.isSafeInteger(value) || value < 0 || value >= 2 ** 62) {
+    throw new Error(`Cannot encode ${value} as a QUIC variable-length integer`);
+  }
+  const length = minQuicVarintLength(value);
+  const encoded = Buffer.alloc(length);
+  let remaining = BigInt(value);
+  for (let index = length - 1; index >= 0; index--) {
+    encoded[index] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  encoded[0] = encoded[0]! | (Math.log2(length) << 6);
+  return encoded;
+}
+
+function readQuicVarint(
+  body: Buffer,
+  offset = 0,
+): { value: number; length: number } {
+  const first = body[offset];
+  if (first === undefined) throw new Error('QUIC varint is absent');
+  const length = 1 << (first >> 6);
+  if (body.length < offset + length) throw new Error('QUIC varint is truncated');
+
+  let value = BigInt(first & 0x3f);
+  for (let index = 1; index < length; index++) {
+    value = (value << 8n) | BigInt(body[offset + index]!);
+  }
+  if (value > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error('QUIC varint exceeds the JavaScript safe integer range');
+  }
+  const numeric = Number(value);
+  if (minQuicVarintLength(numeric) !== length) {
+    throw new Error('QUIC varint is not minimally encoded');
+  }
+  return { value: numeric, length };
+}
+
 function encodeBatchTokenRequest(
   blindedMessages: Uint8Array[],
   truncatedTokenKeyId: number,
@@ -59,9 +106,7 @@ function encodeBatchTokenRequest(
   });
 
   const vector = Buffer.concat(entries);
-  const prefix = Buffer.alloc(2);
-  prefix.writeUInt16BE(vector.length, 0);
-  return Buffer.concat([prefix, vector]);
+  return Buffer.concat([encodeQuicVarint(vector.length), vector]);
 }
 
 function decodeBatchTokenResponse(
@@ -69,39 +114,50 @@ function decodeBatchTokenResponse(
   elementSize: number,
   expectedCount: number,
 ): string[] {
-  if (body.length < 2) {
+  const prefix = readQuicVarint(body);
+  const vector = body.subarray(prefix.length);
+  if (vector.length !== prefix.value) {
     throw new Error(
-      `BatchTokenResponse too short: ${body.length} bytes (expected at least 2)`,
+      `BatchTokenResponse length prefix says ${prefix.value} bytes but ${vector.length} bytes follow`,
     );
   }
+  if (vector.length === 0) throw new Error('BatchTokenResponse vector is empty');
 
-  const vectorLength = body.readUInt16BE(0);
-  const vector = body.subarray(2);
-  if (vector.length !== vectorLength) {
-    throw new Error(
-      `BatchTokenResponse length prefix says ${vectorLength} bytes but ${vector.length} bytes follow`,
-    );
-  }
-  if (vectorLength === 0 || vectorLength % elementSize !== 0) {
-    throw new Error(
-      `BatchTokenResponse vector of ${vectorLength} bytes is not a multiple of the ${elementSize}-byte element size`,
-    );
-  }
-
-  const count = vectorLength / elementSize;
-  if (count !== expectedCount) {
-    throw new Error(
-      `Issuer returned ${count} blind signatures for ${expectedCount} token requests`,
-    );
-  }
-
-  return Array.from({ length: count }, (_, index) =>
-    base64urlEncode(
-      new Uint8Array(
-        vector.subarray(index * elementSize, (index + 1) * elementSize),
+  const signatures: string[] = [];
+  let offset = 0;
+  while (offset < vector.length) {
+    const present = vector[offset++];
+    if (present === 0) {
+      throw new Error(
+        `Issuer refused token request at index ${signatures.length}`,
+      );
+    }
+    if (present !== 1) {
+      throw new Error(`Invalid OptionalTokenResponse presence byte ${present}`);
+    }
+    if (offset + 2 + elementSize > vector.length) {
+      throw new Error('Present GenericTokenResponse is truncated');
+    }
+    const tokenType = vector.readUInt16BE(offset);
+    offset += 2;
+    if (tokenType !== TOKEN_TYPE_BLIND_RSA) {
+      throw new Error(
+        `GenericTokenResponse has unsupported token type 0x${tokenType.toString(16).padStart(4, '0')}`,
+      );
+    }
+    signatures.push(
+      base64urlEncode(
+        new Uint8Array(vector.subarray(offset, offset + elementSize)),
       ),
-    ),
-  );
+    );
+    offset += elementSize;
+  }
+  if (signatures.length !== expectedCount) {
+    throw new Error(
+      `Issuer returned ${signatures.length} token responses for ${expectedCount} token requests`,
+    );
+  }
+  return signatures;
 }
 
 function parseIssuerOrigin(issuer: string): URL {

--- a/packages/sdk/src/resources/interfaces.ts
+++ b/packages/sdk/src/resources/interfaces.ts
@@ -23,6 +23,22 @@ export type AccessTokenProvider = (
   options?: GetAccessTokenOptions,
 ) => Promise<string> | string;
 
+export interface AttestationRequestParams {
+  issuer: string;
+  count: number;
+}
+
+export interface AttestationRequestResult {
+  tokens: string[];
+  issuer: string;
+  token_key_id: string;
+  count: number;
+}
+
+export interface IAttestationsResource {
+  request(params: AttestationRequestParams): Promise<AttestationRequestResult>;
+}
+
 export interface CreateSpendRequestParams {
   payment_details?: string;
   credential_type?: CredentialType;

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -71,7 +71,6 @@ Call `tools/list` to see all available MCP tools.
 - By default all output is in `toon` format. Pass `--format [json|md|yaml]` to change output format.
 - Some commands return a verification or approval URL. **These** must be presented to the user clearly for their action.
 - `--auth <path>` flag to store auth credentials in a specific file instead of the default location. `auth login` writes to this file; all other commands read from it. Example: `link-cli auth login --auth credentials.json`
-- Agent Attestation Tokens are separate from the payment flow. When explicitly needed, request a pool with `link-cli attestations request --count <1-100> [--issuer <https-origin>]`; no AAP-specific OAuth scope is required.
 
 _Recommended_: Run `link-cli --llms` to understand all the available commands. The `--llms-full` output is the canonical reference for parameter names, types, and valid values. Pass `--schema` before invoking a command to understand its parameters and constraints.
 

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -71,7 +71,7 @@ Call `tools/list` to see all available MCP tools.
 - By default all output is in `toon` format. Pass `--format [json|md|yaml]` to change output format.
 - Some commands return a verification or approval URL. **These** must be presented to the user clearly for their action.
 - `--auth <path>` flag to store auth credentials in a specific file instead of the default location. `auth login` writes to this file; all other commands read from it. Example: `link-cli auth login --auth credentials.json`
-- Agent Attestation Tokens are separate from the payment flow. When explicitly needed, request a pool with `link-cli attestations request --count <1-100> [--issuer <https-origin>]`.
+- Agent Attestation Tokens are separate from the payment flow. When explicitly needed, request a pool with `link-cli attestations request --count <1-100> [--issuer <https-origin>]`; no AAP-specific OAuth scope is required.
 
 _Recommended_: Run `link-cli --llms` to understand all the available commands. The `--llms-full` output is the canonical reference for parameter names, types, and valid values. Pass `--schema` before invoking a command to understand its parameters and constraints.
 

--- a/skills/create-payment-credential/SKILL.md
+++ b/skills/create-payment-credential/SKILL.md
@@ -71,6 +71,7 @@ Call `tools/list` to see all available MCP tools.
 - By default all output is in `toon` format. Pass `--format [json|md|yaml]` to change output format.
 - Some commands return a verification or approval URL. **These** must be presented to the user clearly for their action.
 - `--auth <path>` flag to store auth credentials in a specific file instead of the default location. `auth login` writes to this file; all other commands read from it. Example: `link-cli auth login --auth credentials.json`
+- Agent Attestation Tokens are separate from the payment flow. When explicitly needed, request a pool with `link-cli attestations request --count <1-100> [--issuer <https-origin>]`.
 
 _Recommended_: Run `link-cli --llms` to understand all the available commands. The `--llms-full` output is the canonical reference for parameter names, types, and valid values. Pass `--schema` before invoking a command to understand its parameters and constraints.
 


### PR DESCRIPTION
Allow link-cli to issue Blind RSA attestations.

This PR:
- Adds the experimental `link-cli identity attestations request --count 10` command that issues a batch of attestation tokens
- I added this behind `LINK_IDENTITY_COMMANDS=1` flag so that by default this is not visible to a fresh `link-cli` install / you need to know what you're doing